### PR TITLE
DOC: add license badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,18 @@
 audobject
 =========
 
+|license|
+
 Generic interface for serializing objects to yaml_.
 
-.. _yaml:
-    https://yaml.org/
+Have a look at the installation_ and usage_ instructions.
 
-For documentation see:
-http://tools.pp.audeering.com/audobject/
+.. _yaml: https://yaml.org/
+.. _installation: https://audeering.github.io/audobject/install.html
+.. _usage: https://audeering.github.io/audobject/usage.html
+
+
+.. badges images and links:
+.. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
+    :target: https://github.com/audeering/audfactory/blob/master/LICENSE
+    :alt: audfactory's MIT license

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,6 @@
 .. audobject documentation master file
 
 .. include:: ../README.rst
-    :end-line: 9
 
 .. toctree::
     :caption: Getting started


### PR DESCRIPTION
This adds a license badge to the README and triggers the Github Actions the first time.