### PR TITLE
Serialize file paths

### DIFF
--- a/audobject/__init__.py
+++ b/audobject/__init__.py
@@ -14,6 +14,7 @@ from audobject.core.object import (
     Object,
 )
 from audobject.core.resolver import (
+    FilePathResolver,
     TupleResolver,
     TypeResolver,
     ValueResolver,

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -1,7 +1,6 @@
 import functools
 import inspect
 import typing
-import warnings
 
 import audeer
 
@@ -57,6 +56,10 @@ def init_decorator(
 
                 for name, resolver in resolvers.items():
                     resolver_obj = resolver()
+                    # let resolver know if we read from a stream
+                    if define.STREAM_ATTRIBUTE in kwargs:
+                        resolver_obj.__dict__[define.STREAM_ATTRIBUTE] = \
+                            kwargs[define.STREAM_ATTRIBUTE]
                     self.__dict__[define.CUSTOM_VALUE_RESOLVERS][name] = \
                         resolver_obj
                     if name in kwargs and isinstance(
@@ -98,6 +101,10 @@ def init_decorator(
                 if not hasattr(self, define.HIDDEN_ATTRIBUTES):
                     setattr(self, define.HIDDEN_ATTRIBUTES, [])
                 self.__dict__[define.HIDDEN_ATTRIBUTES] += hide
+
+            # if stream was set we can pop it now
+            if define.STREAM_ATTRIBUTE in kwargs:
+                kwargs.pop(define.STREAM_ATTRIBUTE)
 
             func(self, *args, **kwargs)
 

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -57,9 +57,9 @@ def init_decorator(
                 for name, resolver in resolvers.items():
                     resolver_obj = resolver()
                     # let resolver know if we read from a stream
-                    if define.STREAM_ATTRIBUTE in kwargs:
-                        resolver_obj.__dict__[define.STREAM_ATTRIBUTE] = \
-                            kwargs[define.STREAM_ATTRIBUTE]
+                    if define.ROOT_ATTRIBUTE in kwargs:
+                        resolver_obj.__dict__[define.ROOT_ATTRIBUTE] = \
+                            kwargs[define.ROOT_ATTRIBUTE]
                     self.__dict__[define.CUSTOM_VALUE_RESOLVERS][name] = \
                         resolver_obj
                     if name in kwargs and isinstance(
@@ -103,8 +103,8 @@ def init_decorator(
                 self.__dict__[define.HIDDEN_ATTRIBUTES] += hide
 
             # if stream was set we can pop it now
-            if define.STREAM_ATTRIBUTE in kwargs:
-                kwargs.pop(define.STREAM_ATTRIBUTE)
+            if define.ROOT_ATTRIBUTE in kwargs:
+                kwargs.pop(define.ROOT_ATTRIBUTE)
 
             func(self, *args, **kwargs)
 

--- a/audobject/core/define.py
+++ b/audobject/core/define.py
@@ -7,6 +7,7 @@ DEFAULT_VALUE_TYPES = (str, int, float, bool, datetime.datetime)
 CUSTOM_VALUE_RESOLVERS = '_object_resolvers_'
 BORROWED_ATTRIBUTES = '_object_borrowed_'
 HIDDEN_ATTRIBUTES = '_object_hidden_'
+STREAM_ATTRIBUTE = '_object_stream_'
 
 
 class SignatureMismatchWarnLevel:

--- a/audobject/core/define.py
+++ b/audobject/core/define.py
@@ -7,7 +7,7 @@ DEFAULT_VALUE_TYPES = (str, int, float, bool, datetime.datetime)
 CUSTOM_VALUE_RESOLVERS = '_object_resolvers_'
 BORROWED_ATTRIBUTES = '_object_borrowed_'
 HIDDEN_ATTRIBUTES = '_object_hidden_'
-STREAM_ATTRIBUTE = '_object_stream_'
+ROOT_ATTRIBUTE = '_object_root_'
 
 
 class SignatureMismatchWarnLevel:

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -167,14 +167,14 @@ class Object:
     @staticmethod
     def from_dict(
             d: typing.Dict[str, typing.Any],
-            stream: typing.IO = None,
+            root: str = None,
             **kwargs,
     ) -> 'Object':
         r"""Create object from dictionary.
 
         Args:
             d: dictionary with variables
-            stream: set to IO stream when dictionary is read from a file
+            root: if dictionary is read from a file, set to source directory
             kwargs: additional variables
 
         Returns:
@@ -195,7 +195,7 @@ class Object:
             version,
             installed_version,
             params,
-            stream,
+            root,
             **kwargs,
         )
 
@@ -219,7 +219,7 @@ class Object:
                 return Object.from_yaml(fp, **kwargs)
         return Object.from_dict(
             yaml.load(path_or_stream, yaml.Loader),
-            stream=path_or_stream,
+            root=path_or_stream.name,
             **kwargs,
         )
 
@@ -260,7 +260,7 @@ class Object:
             *,
             include_version: bool = True,
             flatten: bool = False,
-            stream: typing.IO = None,
+            root: str = None,
     ) -> typing.Dict[str, DefaultValueType]:
         r"""Converts object to a dictionary.
 
@@ -273,7 +273,7 @@ class Object:
         Args:
             include_version: add version to class name
             flatten: flatten the dictionary
-            stream: set to IO stream if dictionary is written to a file
+            root: if file is written to disk, set to target directory
 
         Returns:
             dictionary that represent the object
@@ -307,7 +307,7 @@ class Object:
                 key,
                 value,
                 include_version,
-                stream,
+                root,
             )
             for key, value in self.arguments.items()
         }
@@ -337,7 +337,7 @@ class Object:
             return yaml.dump(
                 self.to_dict(
                     include_version=include_version,
-                    stream=path_or_stream,
+                    root=path_or_stream.name,
                 ),
                 path_or_stream,
             )
@@ -395,11 +395,11 @@ class Object:
             name: str,
             value: typing.Any,
             include_version: bool,
-            stream: typing.Optional[typing.IO],
+            root: typing.Optional[str],
     ):
         r"""Encode a value by first looking for a custom resolver,
         otherwise switch to default encoder."""
-        value = self._resolve_value(name, value, stream)
+        value = self._resolve_value(name, value, root)
         return Object._encode_value(value, include_version)
 
     @staticmethod
@@ -472,11 +472,11 @@ class Object:
             self,
             name: str,
             value: typing.Any,
-            stream: typing.Optional[typing.IO],
+            root: typing.Optional[str],
     ) -> DefaultValueType:
         if name in self.resolvers:
             # let resolver know if we write to a stream
-            self.resolvers[name].__dict__[define.STREAM_ATTRIBUTE] = stream
+            self.resolvers[name].__dict__[define.ROOT_ATTRIBUTE] = root
             value = self.resolvers[name].encode(value)
         return value
 

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -174,7 +174,7 @@ class Object:
 
         Args:
             d: dictionary with variables
-            root: if dictionary is read from a file, set to source directory
+            root: if dictionary was read from a file, set to source directory
             kwargs: additional variables
 
         Returns:

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -219,7 +219,7 @@ class Object:
                 return Object.from_yaml(fp, **kwargs)
         return Object.from_dict(
             yaml.load(path_or_stream, yaml.Loader),
-            root=path_or_stream.name,
+            root=os.path.dirname(path_or_stream.name),
             **kwargs,
         )
 
@@ -337,7 +337,7 @@ class Object:
             return yaml.dump(
                 self.to_dict(
                     include_version=include_version,
-                    root=path_or_stream.name,
+                    root=os.path.dirname(path_or_stream.name),
                 ),
                 path_or_stream,
             )

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -6,6 +6,7 @@ import typing
 from audobject.core.decorator import (
     init_decorator,
 )
+import audobject.core.define as define
 from audobject.core.dictionary import (
     Dictionary,
 )
@@ -317,12 +318,13 @@ class Parameters(Dictionary):
             ]
         ]
         for name, p in self.items():
-            table.append(
-                [
-                    name, p.value, p.default_value, p.choices,
-                    p.description, p.version,
-                ]
-            )
+            if name != define.STREAM_ATTRIBUTE:
+                table.append(
+                    [
+                        name, p.value, p.default_value, p.choices,
+                        p.description, p.version,
+                    ]
+                )
         padding = 2
         # Longest string in each column
         transposed_table = [list(x) for x in zip(*table)]

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -318,7 +318,7 @@ class Parameters(Dictionary):
             ]
         ]
         for name, p in self.items():
-            if name != define.STREAM_ATTRIBUTE:
+            if name != define.ROOT_ATTRIBUTE:
                 table.append(
                     [
                         name, p.value, p.default_value, p.choices,

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -98,7 +98,7 @@ class FilePathResolver(ValueResolver):
 
         """
         if self.root is not None:
-            root = os.path.dirname(self.root)
+            root = self.root
             value = os.path.join(root, value)
             value = audeer.safe_path(value)
         return value
@@ -119,7 +119,7 @@ class FilePathResolver(ValueResolver):
 
         """
         if self.root is not None:
-            root = os.path.dirname(self.root)
+            root = self.root
             value = os.path.relpath(value, root)
         return value
 

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -19,20 +19,20 @@ class ValueResolver:
 
     """
     def __init__(self):
-        self.__dict__[define.STREAM_ATTRIBUTE] = None
+        self.__dict__[define.ROOT_ATTRIBUTE] = None
 
     @property
-    def stream(self) -> typing.Optional[typing.IO]:
-        r"""Access IO stream.
+    def root(self) -> typing.Optional[str]:
+        r"""Root folder.
 
-        Returns stream when reading from or writing to a file,
-        otherwise ``None`` will be returned.
+        Returns root folder when object is serialized to or from a file,
+        otherwise ``None`` is returned.
 
         Returns:
-            IO stream
+            root directory
 
         """
-        return self.__dict__[define.STREAM_ATTRIBUTE]
+        return self.__dict__[define.ROOT_ATTRIBUTE]
 
     def decode(self, value: DefaultValueType) -> typing.Any:
         r"""Decode value.
@@ -97,8 +97,8 @@ class FilePathResolver(ValueResolver):
             expanded file path
 
         """
-        if self.stream is not None:
-            root = os.path.dirname(self.stream.name)
+        if self.root is not None:
+            root = os.path.dirname(self.root)
             value = os.path.join(root, value)
             value = audeer.safe_path(value)
         return value
@@ -118,8 +118,8 @@ class FilePathResolver(ValueResolver):
             relative file path
 
         """
-        if self.stream is not None:
-            root = os.path.dirname(self.stream.name)
+        if self.root is not None:
+            root = os.path.dirname(self.root)
             value = os.path.relpath(value, root)
         return value
 

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -86,7 +86,7 @@ class FilePathResolver(ValueResolver):
         r"""Decode file path.
 
         If object is read from a file,
-        this will convert the relative file path
+        this will convert a relative file path
         to an absolute path by expanding it
         with the source directory.
 

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -107,7 +107,7 @@ class FilePathResolver(ValueResolver):
         r"""Encode file path.
 
         If object is written to a file,
-        this will convert the file path
+        this will convert a file path
         to a path that is relative to the
         target directory.
 

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -95,10 +95,12 @@ def get_object(
             params[key] = value
 
     # if function has init decorator, add stream to parameters
-    if has_decorator(cls, 'init_decorator'):
+    try:
         params[define.STREAM_ATTRIBUTE] = stream
-
-    return cls(**params)
+        return cls(**params)
+    except TypeError:
+        params.pop(define.STREAM_ATTRIBUTE)
+        return cls(**params)
 
 
 def get_version(module_name: str) -> typing.Optional[str]:
@@ -107,17 +109,6 @@ def get_version(module_name: str) -> typing.Optional[str]:
         return module.__version__
     else:
         return None
-
-
-def has_decorator(
-        cls: type,
-        name: str,
-) -> bool:
-    r"""Check if class method has decorator with this name."""
-    lines = [line.strip() for line in inspect.getsourcelines(cls)[0]]
-    lines = [line for line in lines if line.startswith('@')]
-    lines = [line for line in lines if name in line]
-    return len(lines) > 0
 
 
 def is_class(value: typing.Any):

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -22,6 +22,7 @@ def get_object(
         version: str,
         installed_version: str,
         params: dict,
+        stream: typing.Optional[typing.IO],
         **kwargs,
 ) -> typing.Any:
     r"""Create object from arguments."""
@@ -93,6 +94,10 @@ def get_object(
         if key in supported_params:
             params[key] = value
 
+    # if function has init decorator, add stream to parameters
+    if has_decorator(cls, 'init_decorator'):
+        params[define.STREAM_ATTRIBUTE] = stream
+
     return cls(**params)
 
 
@@ -102,6 +107,17 @@ def get_version(module_name: str) -> typing.Optional[str]:
         return module.__version__
     else:
         return None
+
+
+def has_decorator(
+        cls: type,
+        name: str,
+) -> bool:
+    r"""Check if class method has decorator with this name."""
+    lines = [line.strip() for line in inspect.getsourcelines(cls)[0]]
+    lines = [line for line in lines if line.startswith('@')]
+    lines = [line for line in lines if name in line]
+    return len(lines) > 0
 
 
 def is_class(value: typing.Any):

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -94,7 +94,15 @@ def get_object(
         if key in supported_params:
             params[key] = value
 
-    # if function has init decorator, add stream to parameters
+    # If function has init decorator, add stream to parameters.
+    # The additional parameter will be popped by the decorator
+    # before the object is created.
+    # If the class does not have a decorator
+    # a TypeError will be raised since we call
+    # the class with an unexpected argument.
+    # Unfortunately, there is no straight-forward way
+    # to check if a method of a class has a decorator
+    # so we have to use a try-except block
     try:
         params[define.STREAM_ATTRIBUTE] = stream
         return cls(**params)

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -22,7 +22,7 @@ def get_object(
         version: str,
         installed_version: str,
         params: dict,
-        stream: typing.Optional[typing.IO],
+        root: typing.Optional[str],
         **kwargs,
 ) -> typing.Any:
     r"""Create object from arguments."""
@@ -104,10 +104,10 @@ def get_object(
     # to check if a method of a class has a decorator
     # so we have to use a try-except block
     try:
-        params[define.STREAM_ATTRIBUTE] = stream
+        params[define.ROOT_ATTRIBUTE] = root
         return cls(**params)
     except TypeError:
-        params.pop(define.STREAM_ATTRIBUTE)
+        params.pop(define.ROOT_ATTRIBUTE)
         return cls(**params)
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,12 @@ init_decorator
 
 .. autofunction:: init_decorator
 
+FilePathResolver
+----------------
+
+.. autoclass:: FilePathResolver
+    :members:
+
 Object
 ------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -614,7 +614,7 @@ of the YAML file.
     content
 
 
-And when we re-instantiate the object
+When we re-instantiate the object
 the path gets expanded again.
 
 .. jupyter-execute::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -630,9 +630,9 @@ the path gets expanded again.
     o2 = audobject.Object.from_yaml(yaml_path)
     o2.read()
 
-This will also work from another location
-(note that we also move the referenced file here,
-as its relative location to the YAML file must not change).
+This will also work from another location.
+Note that we have to move all referenced files as well,
+as their relative location to the YAML file must not change.
 
 .. jupyter-execute::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -557,7 +557,7 @@ Resolve file paths
 
 Portability is a core feature of
 :mod:`audobject`.
-Now assume we have an object
+Assume we have an object
 that takes as argument the path to a file.
 When we serialize the object
 we want to make sure that:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -605,7 +605,7 @@ Here, we create a file and pass it to the object.
     o = MyObjectWithFile(res_path)
     o.read()
 
-But when we serialize the object,
+When we serialize the object,
 the path is
 stored relative to the directory
 of the YAML file.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -631,12 +631,12 @@ This will also work from another location.
     yaml_path_new = os.path.join('some', 'where', 'yaml', 'object.yaml')
     audeer.mkdir(os.path.dirname(yaml_path_new))
     shutil.move(yaml_path, yaml_path_new)
+    # move referenced files
 
     o3 = audobject.Object.from_yaml(yaml_path_new)
     o3.path
 
-Note that when moving the YAML file to another location,
-referenced files have to be moved, too,
+Note that referenced files have to be moved, too,
 as the relative location to the YAML file must not change.
 
 Flat dictionary

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -592,6 +592,7 @@ Here, we instantiate the object with an absolute path.
 
 
     path = os.path.join('re', 'source.txt')  # ./re/source.txt
+    path = audeer.safe_path(path)
     o = MyObjectWithFile(path)
     o.path
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -613,7 +613,6 @@ of the YAML file.
         content = yaml.load(fp, Loader=yaml.Loader)
     content
 
-
 When we re-instantiate the object
 the path gets expanded again.
 
@@ -635,6 +634,10 @@ This will also work from another location.
 
     o3 = audobject.Object.from_yaml(yaml_path_new)
     o3.path
+
+Note that when moving the YAML file to another location,
+referenced files have to be moved, too,
+as the relative location to the YAML file must not change.
 
 Flat dictionary
 ---------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -606,7 +606,7 @@ Here, we create a file and pass it to the object.
     o.read()
 
 But when we serialize the object,
-we can see that the path is
+the path is
 stored relative to the directory
 of the YAML file.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -642,7 +642,6 @@ as its relative location to the YAML file must not change).
     shutil.move(root, new_root)
 
     yaml_path_new = os.path.join(new_root, 'yaml', 'object.yaml')
-
     o3 = audobject.Object.from_yaml(yaml_path_new)
     o3.read()
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+
+import audeer
+import audobject
+
+
+class ObjectWithFile(audobject.Object):
+
+    @audobject.init_decorator(
+        resolvers={
+            'path': audobject.FilePathResolver,
+        }
+    )
+    def __init__(
+            self,
+            path: str,
+    ):
+        self.path = path
+
+
+def test_filepath(tmpdir):
+
+    root = os.path.join(tmpdir, 'test')
+    new_root = os.path.join(tmpdir, 'some', 'where', 'else')
+
+    # create resource file
+    resource_path = os.path.join(root, 're', 'source.txt')
+    audeer.mkdir(os.path.dirname(resource_path))
+    with open(resource_path, 'w'):
+        pass
+
+    # create object and serialize
+    yaml_path = os.path.join(root, 'yaml', 'object.yaml')
+    o = ObjectWithFile(resource_path)
+    o.to_yaml(yaml_path, include_version=False)
+
+    # move files to another location
+    shutil.move(root, new_root)
+    new_yaml_path = os.path.join(new_root, 'yaml', 'object.yaml')
+
+    # re-instantiate object from new location and assert path exists
+    o2 = audobject.Object.from_yaml(new_yaml_path)
+    assert isinstance(o2, ObjectWithFile)
+    assert os.path.exists(o2.path)


### PR DESCRIPTION
This adds a feature - as simple as it sounds - I have been struggeling with for some time. It will be useful if a user wants to serialize objects that require input from external files (e.g. a file storing model weights etc.). If we would simply store the file path as it is, we get a YAML that is not be portable as it will not find the files once we move it to another location.

As a solution this adds `FilePathResolver` to properly save and recover files path arguments. Here's what it does:

1. when the object is serialized convert the original file path to a path relative to the output directory
2. when the object is re-instantiated expand the file path again with the current input directory

Example from the usage section:

![image](https://user-images.githubusercontent.com/10383417/125493789-ee3e40b4-c044-4ae6-a26d-3b0fdb43c980.png)