### PR TITLE
Module-level load functions

### DIFF
--- a/audobject/__init__.py
+++ b/audobject/__init__.py
@@ -1,4 +1,9 @@
 from audobject import define
+from audobject.core.api import (
+    load_from_dict,
+    load_from_yaml,
+    load_from_yaml_s,
+)
 from audobject.core.config import config
 from audobject.core.parameter import (
     Parameter,

--- a/audobject/__init__.py
+++ b/audobject/__init__.py
@@ -1,8 +1,8 @@
 from audobject import define
 from audobject.core.api import (
-    load_from_dict,
-    load_from_yaml,
-    load_from_yaml_s,
+    from_dict,
+    from_yaml,
+    from_yaml_s,
 )
 from audobject.core.config import config
 from audobject.core.parameter import (

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -80,7 +80,7 @@ def load_from_yaml(
     """
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
-            return Object.from_yaml(fp, **kwargs)
+            return load_from_yaml(fp, **kwargs)
     return load_from_dict(
         yaml.load(path_or_stream, yaml.Loader),
         root=os.path.dirname(path_or_stream.name),

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -7,7 +7,7 @@ from audobject.core.object import Object
 import audobject.core.utils as utils
 
 
-def load_from_dict(
+def from_dict(
         d: typing.Dict[str, typing.Any],
         root: str = None,
         **kwargs,
@@ -42,7 +42,7 @@ def load_from_dict(
     )
 
 
-def load_from_yaml(
+def from_yaml(
         path_or_stream: typing.Union[str, typing.IO],
         **kwargs,
 ) -> 'Object':
@@ -58,15 +58,15 @@ def load_from_yaml(
     """
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
-            return load_from_yaml(fp, **kwargs)
-    return load_from_dict(
+            return from_yaml(fp, **kwargs)
+    return from_dict(
         yaml.load(path_or_stream, yaml.Loader),
         root=os.path.dirname(path_or_stream.name),
         **kwargs,
     )
 
 
-def load_from_yaml_s(
+def from_yaml_s(
         yaml_string: str,
         **kwargs,
 ) -> 'Object':
@@ -80,7 +80,7 @@ def load_from_yaml_s(
         object
 
     """
-    return load_from_dict(
+    return from_dict(
         yaml.load(yaml_string, yaml.Loader),
         **kwargs,
     )
@@ -99,7 +99,7 @@ def _decode_value(
         elif isinstance(value_to_decode, dict):
             name = next(iter(value_to_decode))
             if isinstance(name, Object) or utils.is_class(name):
-                return load_from_dict(value_to_decode, **kwargs)
+                return from_dict(value_to_decode, **kwargs)
             else:
                 return {
                     k: _decode_value(v, **kwargs) for k, v in

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -7,28 +7,6 @@ from audobject.core.object import Object
 import audobject.core.utils as utils
 
 
-def _decode_value(
-        value_to_decode: typing.Any,
-        **kwargs,
-) -> typing.Any:
-    r"""Decode value."""
-    if value_to_decode:  # not empty
-        if isinstance(value_to_decode, list):
-            return [
-                _decode_value(v, **kwargs) for v in value_to_decode
-            ]
-        elif isinstance(value_to_decode, dict):
-            name = next(iter(value_to_decode))
-            if isinstance(name, Object) or utils.is_class(name):
-                return load_from_dict(value_to_decode, **kwargs)
-            else:
-                return {
-                    k: _decode_value(v, **kwargs) for k, v in
-                    value_to_decode.items()
-                }
-    return value_to_decode
-
-
 def load_from_dict(
         d: typing.Dict[str, typing.Any],
         root: str = None,
@@ -106,3 +84,25 @@ def load_from_yaml_s(
         yaml.load(yaml_string, yaml.Loader),
         **kwargs,
     )
+
+
+def _decode_value(
+        value_to_decode: typing.Any,
+        **kwargs,
+) -> typing.Any:
+    r"""Decode value."""
+    if value_to_decode:  # not empty
+        if isinstance(value_to_decode, list):
+            return [
+                _decode_value(v, **kwargs) for v in value_to_decode
+            ]
+        elif isinstance(value_to_decode, dict):
+            name = next(iter(value_to_decode))
+            if isinstance(name, Object) or utils.is_class(name):
+                return load_from_dict(value_to_decode, **kwargs)
+            else:
+                return {
+                    k: _decode_value(v, **kwargs) for k, v in
+                    value_to_decode.items()
+                }
+    return value_to_decode

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -15,9 +15,10 @@ def from_dict(
     r"""Create object from dictionary.
 
     Args:
-        d: dictionary with variables
+        d: dictionary with arguments
         root: if dictionary was read from a file, set to source directory
-        kwargs: additional variables
+        kwargs: additional keyword arguments to override the values in the
+            dictionary and default values of hidden arguments
 
     Returns:
         object
@@ -50,7 +51,8 @@ def from_yaml(
 
     Args:
         path_or_stream: file path or stream
-        kwargs: additional variables
+        kwargs: additional keyword arguments to override the values in the
+            YAML file and default values of hidden arguments
 
     Returns:
         object
@@ -74,7 +76,8 @@ def from_yaml_s(
 
     Args:
         yaml_string: YAML string
-        kwargs: additional variables
+        kwargs: additional keyword arguments to override the values in the
+            YAML string and default values of hidden arguments
 
     Returns:
         object

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -20,7 +20,7 @@ def _decode_value(
         elif isinstance(value_to_decode, dict):
             name = next(iter(value_to_decode))
             if isinstance(name, Object) or utils.is_class(name):
-                return Object.from_dict(value_to_decode, **kwargs)
+                return load_from_dict(value_to_decode, **kwargs)
             else:
                 return {
                     k: _decode_value(v, **kwargs) for k, v in
@@ -80,7 +80,7 @@ def load_from_yaml(
     """
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
-            return Object.from_yaml(fp, **kwargs)
+            return load_from_yaml(fp, **kwargs)
     return load_from_dict(
         yaml.load(path_or_stream, yaml.Loader),
         root=os.path.dirname(path_or_stream.name),

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -80,7 +80,7 @@ def load_from_yaml(
     """
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
-            return load_from_yaml(fp, **kwargs)
+            return Object.from_yaml(fp, **kwargs)
     return load_from_dict(
         yaml.load(path_or_stream, yaml.Loader),
         root=os.path.dirname(path_or_stream.name),

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -1,0 +1,108 @@
+import os
+import typing
+
+import oyaml as yaml
+
+from audobject.core.object import Object
+import audobject.core.utils as utils
+
+
+def _decode_value(
+        value_to_decode: typing.Any,
+        **kwargs,
+) -> typing.Any:
+    r"""Decode value."""
+    if value_to_decode:  # not empty
+        if isinstance(value_to_decode, list):
+            return [
+                _decode_value(v, **kwargs) for v in value_to_decode
+            ]
+        elif isinstance(value_to_decode, dict):
+            name = next(iter(value_to_decode))
+            if isinstance(name, Object) or utils.is_class(name):
+                return Object.from_dict(value_to_decode, **kwargs)
+            else:
+                return {
+                    k: _decode_value(v, **kwargs) for k, v in
+                    value_to_decode.items()
+                }
+    return value_to_decode
+
+
+def load_from_dict(
+        d: typing.Dict[str, typing.Any],
+        root: str = None,
+        **kwargs,
+) -> 'Object':
+    r"""Create object from dictionary.
+
+    Args:
+        d: dictionary with variables
+        root: if dictionary was read from a file, set to source directory
+        kwargs: additional variables
+
+    Returns:
+        object
+
+    Raises:
+        RuntimeError: if a mandatory argument of the object
+            is missing in the dictionary
+
+    """
+    name = next(iter(d))
+    cls, version, installed_version = utils.get_class(name)
+    params = {}
+    for key, value in d[name].items():
+        params[key] = _decode_value(value, **kwargs)
+    return utils.get_object(
+        cls,
+        version,
+        installed_version,
+        params,
+        root,
+        **kwargs,
+    )
+
+
+def load_from_yaml(
+        path_or_stream: typing.Union[str, typing.IO],
+        **kwargs,
+) -> 'Object':
+    r"""Create object from YAML file.
+
+    Args:
+        path_or_stream: file path or stream
+        kwargs: additional variables
+
+    Returns:
+        object
+
+    """
+    if isinstance(path_or_stream, str):
+        with open(path_or_stream, 'r') as fp:
+            return Object.from_yaml(fp, **kwargs)
+    return load_from_dict(
+        yaml.load(path_or_stream, yaml.Loader),
+        root=os.path.dirname(path_or_stream.name),
+        **kwargs,
+    )
+
+
+def load_from_yaml_s(
+        yaml_string: str,
+        **kwargs,
+) -> 'Object':
+    r"""Create object from YAML string.
+
+    Args:
+        yaml_string: YAML string
+        kwargs: additional variables
+
+    Returns:
+        object
+
+    """
+    return load_from_dict(
+        yaml.load(yaml_string, yaml.Loader),
+        **kwargs,
+    )

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -169,7 +169,7 @@ class Object:
             d: typing.Dict[str, typing.Any],
             root: str = None,
             **kwargs,
-    ) -> 'Object':
+    ) -> 'Object':  # pragma: no cover
         r"""Create object from dictionary.
 
         Args:
@@ -186,13 +186,18 @@ class Object:
 
         """
         from audobject.core.api import load_from_dict
+        message = (
+            'audobject.Object.from_dict() is deprecated and will be removed '
+            'with version 1.0.0. Use audobject.load_from_dict() instead.'
+        )
+        warnings.warn(message, category=UserWarning, stacklevel=2)
         return load_from_dict(d, root, **kwargs)
 
     @staticmethod
     def from_yaml(
             path_or_stream: typing.Union[str, typing.IO],
             **kwargs,
-    ) -> 'Object':
+    ) -> 'Object':  # pragma: no cover
         r"""Create object from YAML file.
 
         Args:
@@ -204,13 +209,18 @@ class Object:
 
         """
         from audobject.core.api import load_from_yaml
+        message = (
+            'audobject.Object.from_yaml() is deprecated and will be removed '
+            'with version 1.0.0. Use audobject.load_from_yaml() instead.'
+        )
+        warnings.warn(message, category=UserWarning, stacklevel=2)
         return load_from_yaml(path_or_stream, **kwargs)
 
     @staticmethod
     def from_yaml_s(
             yaml_string: str,
             **kwargs,
-    ) -> 'Object':
+    ) -> 'Object':  # pragma: no cover
         r"""Create object from YAML string.
 
         Args:
@@ -222,6 +232,11 @@ class Object:
 
         """
         from audobject.core.api import load_from_yaml_s
+        message = (
+            'audobject.Object.from_yaml_s() is deprecated and will be removed '
+            'with version 1.0.0. Use audobject.load_from_yaml_s() instead.'
+        )
+        warnings.warn(message, category=UserWarning, stacklevel=2)
         return load_from_yaml_s(yaml_string, **kwargs)
 
     @property

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -170,21 +170,6 @@ class Object:
             root: str = None,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        r"""Create object from dictionary.
-
-        Args:
-            d: dictionary with variables
-            root: if dictionary was read from a file, set to source directory
-            kwargs: additional variables
-
-        Returns:
-            object
-
-        Raises:
-            RuntimeError: if a mandatory argument of the object
-                is missing in the dictionary
-
-        """
         from audobject.core.api import load_from_dict
         message = (
             'audobject.Object.from_dict() is deprecated and will be removed '
@@ -198,16 +183,6 @@ class Object:
             path_or_stream: typing.Union[str, typing.IO],
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        r"""Create object from YAML file.
-
-        Args:
-            path_or_stream: file path or stream
-            kwargs: additional variables
-
-        Returns:
-            object
-
-        """
         from audobject.core.api import load_from_yaml
         message = (
             'audobject.Object.from_yaml() is deprecated and will be removed '
@@ -221,16 +196,6 @@ class Object:
             yaml_string: str,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        r"""Create object from YAML string.
-
-        Args:
-            yaml_string: YAML string
-            kwargs: additional variables
-
-        Returns:
-            object
-
-        """
         from audobject.core.api import load_from_yaml_s
         message = (
             'audobject.Object.from_yaml_s() is deprecated and will be removed '

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -170,39 +170,39 @@ class Object:
             root: str = None,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        from audobject.core.api import load_from_dict
+        from audobject.core.api import from_dict
         message = (
             'audobject.Object.from_dict() is deprecated and will be removed '
             'with version 1.0.0. Use audobject.load_from_dict() instead.'
         )
         warnings.warn(message, category=UserWarning, stacklevel=2)
-        return load_from_dict(d, root, **kwargs)
+        return from_dict(d, root, **kwargs)
 
     @staticmethod
     def from_yaml(
             path_or_stream: typing.Union[str, typing.IO],
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        from audobject.core.api import load_from_yaml
+        from audobject.core.api import from_yaml
         message = (
             'audobject.Object.from_yaml() is deprecated and will be removed '
             'with version 1.0.0. Use audobject.load_from_yaml() instead.'
         )
         warnings.warn(message, category=UserWarning, stacklevel=2)
-        return load_from_yaml(path_or_stream, **kwargs)
+        return from_yaml(path_or_stream, **kwargs)
 
     @staticmethod
     def from_yaml_s(
             yaml_string: str,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
-        from audobject.core.api import load_from_yaml_s
+        from audobject.core.api import from_yaml_s
         message = (
             'audobject.Object.from_yaml_s() is deprecated and will be removed '
             'with version 1.0.0. Use audobject.load_from_yaml_s() instead.'
         )
         warnings.warn(message, category=UserWarning, stacklevel=2)
-        return load_from_yaml_s(yaml_string, **kwargs)
+        return from_yaml_s(yaml_string, **kwargs)
 
     @property
     def resolvers(self) -> typing.Dict[str, ValueResolver]:

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -185,19 +185,8 @@ class Object:
                 is missing in the dictionary
 
         """
-        name = next(iter(d))
-        cls, version, installed_version = utils.get_class(name)
-        params = {}
-        for key, value in d[name].items():
-            params[key] = Object._decode_value(value, **kwargs)
-        return utils.get_object(
-            cls,
-            version,
-            installed_version,
-            params,
-            root,
-            **kwargs,
-        )
+        from audobject.core.api import load_from_dict
+        return load_from_dict(d, root, **kwargs)
 
     @staticmethod
     def from_yaml(
@@ -214,14 +203,8 @@ class Object:
             object
 
         """
-        if isinstance(path_or_stream, str):
-            with open(path_or_stream, 'r') as fp:
-                return Object.from_yaml(fp, **kwargs)
-        return Object.from_dict(
-            yaml.load(path_or_stream, yaml.Loader),
-            root=os.path.dirname(path_or_stream.name),
-            **kwargs,
-        )
+        from audobject.core.api import load_from_yaml
+        return load_from_yaml(path_or_stream, **kwargs)
 
     @staticmethod
     def from_yaml_s(
@@ -238,10 +221,8 @@ class Object:
             object
 
         """
-        return Object.from_dict(
-            yaml.load(yaml_string, yaml.Loader),
-            **kwargs,
-        )
+        from audobject.core.api import load_from_yaml_s
+        return load_from_yaml_s(yaml_string, **kwargs)
 
     @property
     def resolvers(self) -> typing.Dict[str, ValueResolver]:
@@ -367,28 +348,6 @@ class Object:
 
         """  # noqa: E501
         return yaml.dump(self.to_dict(include_version=include_version))
-
-    @staticmethod
-    def _decode_value(
-            value_to_decode: typing.Any,
-            **kwargs,
-    ) -> typing.Any:
-        r"""Decode value."""
-        if value_to_decode:  # not empty
-            if isinstance(value_to_decode, list):
-                return [
-                    Object._decode_value(v, **kwargs) for v in value_to_decode
-                ]
-            elif isinstance(value_to_decode, dict):
-                name = next(iter(value_to_decode))
-                if isinstance(name, Object) or utils.is_class(name):
-                    return Object.from_dict(value_to_decode, **kwargs)
-                else:
-                    return {
-                        k: Object._decode_value(v, **kwargs) for k, v in
-                        value_to_decode.items()
-                    }
-        return value_to_decode
 
     def _encode_variable(
             self,

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -165,43 +165,40 @@ class Object:
         return audeer.uid(from_string=string)
 
     @staticmethod
+    @audeer.deprecated(
+        removal_version='1.0.0',
+        alternative='audobject.from_dict',
+    )
     def from_dict(
             d: typing.Dict[str, typing.Any],
             root: str = None,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
         from audobject.core.api import from_dict
-        message = (
-            'audobject.Object.from_dict() is deprecated and will be removed '
-            'with version 1.0.0. Use audobject.load_from_dict() instead.'
-        )
-        warnings.warn(message, category=UserWarning, stacklevel=2)
         return from_dict(d, root, **kwargs)
 
     @staticmethod
+    @audeer.deprecated(
+        removal_version='1.0.0',
+        alternative='audobject.from_yaml',
+    )
     def from_yaml(
             path_or_stream: typing.Union[str, typing.IO],
             **kwargs,
     ) -> 'Object':  # pragma: no cover
         from audobject.core.api import from_yaml
-        message = (
-            'audobject.Object.from_yaml() is deprecated and will be removed '
-            'with version 1.0.0. Use audobject.load_from_yaml() instead.'
-        )
-        warnings.warn(message, category=UserWarning, stacklevel=2)
         return from_yaml(path_or_stream, **kwargs)
 
     @staticmethod
+    @audeer.deprecated(
+        removal_version='1.0.0',
+        alternative='audobject.from_yaml_s',
+    )
     def from_yaml_s(
             yaml_string: str,
             **kwargs,
     ) -> 'Object':  # pragma: no cover
         from audobject.core.api import from_yaml_s
-        message = (
-            'audobject.Object.from_yaml_s() is deprecated and will be removed '
-            'with version 1.0.0. Use audobject.load_from_yaml_s() instead.'
-        )
-        warnings.warn(message, category=UserWarning, stacklevel=2)
         return from_yaml_s(yaml_string, **kwargs)
 
     @property

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,21 @@ FilePathResolver
 .. autoclass:: FilePathResolver
     :members:
 
+load_from_dict
+--------------
+
+.. autofunction:: load_from_dict
+
+load_from_yaml
+--------------
+
+.. autofunction:: load_from_yaml
+
+load_from_yaml_s
+----------------
+
+.. autofunction:: load_from_yaml_s
+
 Object
 ------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,20 +27,20 @@ FilePathResolver
 .. autoclass:: FilePathResolver
     :members:
 
-load_from_dict
+from_dict
 --------------
 
-.. autofunction:: load_from_dict
+.. autofunction:: from_dict
 
-load_from_yaml
+from_yaml
 --------------
 
-.. autofunction:: load_from_yaml
+.. autofunction:: from_yaml
 
-load_from_yaml_s
+from_yaml_s
 ----------------
 
-.. autofunction:: load_from_yaml_s
+.. autofunction:: from_yaml_s
 
 Object
 ------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -73,7 +73,7 @@ And we can re-instantiate the object from it.
 
 .. jupyter-execute::
 
-    o2 = audobject.load_from_dict(o_dict)
+    o2 = audobject.from_dict(o_dict)
     print(o2)
 
 We can also convert it to YAML.
@@ -87,7 +87,7 @@ And create the object from YAML.
 
 .. jupyter-execute::
 
-    o3 = audobject.load_from_yaml_s(o_yaml)
+    o3 = audobject.from_yaml_s(o_yaml)
     print(o3)
 
 If we want, we can override
@@ -95,7 +95,7 @@ arguments when we instantiate an object.
 
 .. jupyter-execute::
 
-    o4 = audobject.load_from_yaml_s(
+    o4 = audobject.from_yaml_s(
         o_yaml,
         string='I was set to a different value!'
     )
@@ -107,7 +107,7 @@ Or save an object to disk and re-instantiate it from there.
 
     file = 'my.yaml'
     o.to_yaml(file)
-    o5 = audobject.load_from_yaml(file)
+    o5 = audobject.from_yaml(file)
     print(o5)
 
 Object ID
@@ -131,7 +131,7 @@ When an object is serialized the ID does not change.
 
 .. jupyter-execute::
 
-    o3 = audobject.load_from_yaml_s(o.to_yaml_s())
+    o3 = audobject.from_yaml_s(o.to_yaml_s())
     print(o3.id == o.id)
 
 Objects with different arguments get different IDs.
@@ -180,7 +180,7 @@ from YAML, we'll get an error.
     :raises:
 
     bad_yaml = bad.to_yaml_s()
-    bad2 = audobject.load_from_yaml_s(bad_yaml)
+    bad2 = audobject.from_yaml_s(bad_yaml)
     print(bad2)
 
 However, in the next section we'll learn
@@ -242,14 +242,14 @@ and we won't see debug messages.
 
 .. jupyter-execute::
 
-    o2 = audobject.load_from_yaml_s(o_yaml)
+    o2 = audobject.from_yaml_s(o_yaml)
     print(o2)
 
 However, we can set ``verbose=True`` when we load the object.
 
 .. jupyter-execute::
 
-    o3 = audobject.load_from_yaml_s(o_yaml, verbose=True)
+    o3 = audobject.from_yaml_s(o_yaml, verbose=True)
     print(o3)
 
 Note that hidden arguments are not taken into account for the UID.
@@ -433,7 +433,7 @@ From which we can re-instantiate the object.
 
 .. jupyter-execute::
 
-    w2 = audobject.load_from_yaml_s(w_yaml)
+    w2 = audobject.from_yaml_s(w_yaml)
     print(w2)
 
 Value resolver
@@ -627,7 +627,7 @@ the path gets expanded again.
 
 .. jupyter-execute::
 
-    o2 = audobject.load_from_yaml(yaml_path)
+    o2 = audobject.from_yaml(yaml_path)
     o2.read()
 
 This will also work from another location.
@@ -642,7 +642,7 @@ as their relative location to the YAML file must not change.
     shutil.move(root, new_root)
 
     yaml_path_new = os.path.join(new_root, 'yaml', 'object.yaml')
-    o3 = audobject.load_from_yaml(yaml_path_new)
+    o3 = audobject.from_yaml(yaml_path_new)
     o3.read()
 
 
@@ -744,7 +744,7 @@ the strings are now separated by comma.
 
 .. jupyter-execute::
 
-    o2 = audobject.load_from_yaml_s(o_yaml)
+    o2 = audobject.from_yaml_s(o_yaml)
     print(o2)
 
 In the next release, we decide to introduce an argument
@@ -779,7 +779,7 @@ for the new argument.
     :stderr:
     :raises:
 
-    audobject.load_from_yaml_s(o_yaml)
+    audobject.from_yaml_s(o_yaml)
 
 Since we want to be backward compatible,
 we decide to release a bug fix,
@@ -810,7 +810,7 @@ It works, because it now has a default value for the missing argument.
 
 .. jupyter-execute::
 
-    o3 = audobject.load_from_yaml_s(o_yaml)
+    o3 = audobject.from_yaml_s(o_yaml)
     print(o3)
 
 Finally, we will do it the other way round.
@@ -849,7 +849,7 @@ And load it with ``1.0.0``.
         def __str__(self) -> str:
             return ' '.join([self.string] * self.num_repeat)
 
-    o5 = audobject.load_from_yaml_s(o4_yaml)
+    o5 = audobject.from_yaml_s(o4_yaml)
     print(o5)
 
 In fact, it works, too.
@@ -895,7 +895,7 @@ And we can read/write the dictionary from/to a file.
 
     file = 'dict.yaml'
     d.to_yaml(file)
-    d3 = audobject.load_from_yaml(file)
+    d3 = audobject.from_yaml(file)
     print(d3)
 
 Parameters
@@ -1034,7 +1034,7 @@ Last but not least, we can read/write the parameters from/to a file.
 
     file = 'params.yaml'
     params.to_yaml(file)
-    params2 = audobject.load_from_yaml(file)
+    params2 = audobject.from_yaml(file)
     print(params2)
 
 .. reset working directory and clean up

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -73,7 +73,7 @@ And we can re-instantiate the object from it.
 
 .. jupyter-execute::
 
-    o2 = o.from_dict(o_dict)
+    o2 = audobject.load_from_dict(o_dict)
     print(o2)
 
 We can also convert it to YAML.
@@ -87,7 +87,7 @@ And create the object from YAML.
 
 .. jupyter-execute::
 
-    o3 = audobject.Object.from_yaml_s(o_yaml)
+    o3 = audobject.load_from_yaml_s(o_yaml)
     print(o3)
 
 If we want, we can override
@@ -95,7 +95,7 @@ arguments when we instantiate an object.
 
 .. jupyter-execute::
 
-    o4 = audobject.Object.from_yaml_s(
+    o4 = audobject.load_from_yaml_s(
         o_yaml,
         string='I was set to a different value!'
     )
@@ -107,7 +107,7 @@ Or save an object to disk and re-instantiate it from there.
 
     file = 'my.yaml'
     o.to_yaml(file)
-    o5 = audobject.Object.from_yaml(file)
+    o5 = audobject.load_from_yaml(file)
     print(o5)
 
 Object ID
@@ -131,7 +131,7 @@ When an object is serialized the ID does not change.
 
 .. jupyter-execute::
 
-    o3 = audobject.Object.from_yaml_s(o.to_yaml_s())
+    o3 = audobject.load_from_yaml_s(o.to_yaml_s())
     print(o3.id == o.id)
 
 Objects with different arguments get different IDs.
@@ -180,7 +180,7 @@ from YAML, we'll get an error.
     :raises:
 
     bad_yaml = bad.to_yaml_s()
-    bad2 = audobject.Object.from_yaml_s(bad_yaml)
+    bad2 = audobject.load_from_yaml_s(bad_yaml)
     print(bad2)
 
 However, in the next section we'll learn
@@ -242,14 +242,14 @@ and we won't see debug messages.
 
 .. jupyter-execute::
 
-    o2 = audobject.Object.from_yaml_s(o_yaml)
+    o2 = audobject.load_from_yaml_s(o_yaml)
     print(o2)
 
 However, we can set ``verbose=True`` when we load the object.
 
 .. jupyter-execute::
 
-    o3 = audobject.Object.from_yaml_s(o_yaml, verbose=True)
+    o3 = audobject.load_from_yaml_s(o_yaml, verbose=True)
     print(o3)
 
 Note that hidden arguments are not taken into account for the UID.
@@ -433,7 +433,7 @@ From which we can re-instantiate the object.
 
 .. jupyter-execute::
 
-    w2 = audobject.Object.from_yaml_s(w_yaml)
+    w2 = audobject.load_from_yaml_s(w_yaml)
     print(w2)
 
 Value resolver
@@ -627,7 +627,7 @@ the path gets expanded again.
 
 .. jupyter-execute::
 
-    o2 = audobject.Object.from_yaml(yaml_path)
+    o2 = audobject.load_from_yaml(yaml_path)
     o2.read()
 
 This will also work from another location.
@@ -642,7 +642,7 @@ as their relative location to the YAML file must not change.
     shutil.move(root, new_root)
 
     yaml_path_new = os.path.join(new_root, 'yaml', 'object.yaml')
-    o3 = audobject.Object.from_yaml(yaml_path_new)
+    o3 = audobject.load_from_yaml(yaml_path_new)
     o3.read()
 
 
@@ -744,7 +744,7 @@ the strings are now separated by comma.
 
 .. jupyter-execute::
 
-    o2 = audobject.Object.from_yaml_s(o_yaml)
+    o2 = audobject.load_from_yaml_s(o_yaml)
     print(o2)
 
 In the next release, we decide to introduce an argument
@@ -779,7 +779,7 @@ for the new argument.
     :stderr:
     :raises:
 
-    audobject.Object.from_yaml_s(o_yaml)
+    audobject.load_from_yaml_s(o_yaml)
 
 Since we want to be backward compatible,
 we decide to release a bug fix,
@@ -810,7 +810,7 @@ It works, because it now has a default value for the missing argument.
 
 .. jupyter-execute::
 
-    o3 = audobject.Object.from_yaml_s(o_yaml)
+    o3 = audobject.load_from_yaml_s(o_yaml)
     print(o3)
 
 Finally, we will do it the other way round.
@@ -849,7 +849,7 @@ And load it with ``1.0.0``.
         def __str__(self) -> str:
             return ' '.join([self.string] * self.num_repeat)
 
-    o5 = audobject.Object.from_yaml_s(o4_yaml)
+    o5 = audobject.load_from_yaml_s(o4_yaml)
     print(o5)
 
 In fact, it works, too.
@@ -895,7 +895,7 @@ And we can read/write the dictionary from/to a file.
 
     file = 'dict.yaml'
     d.to_yaml(file)
-    d3 = audobject.Object.from_yaml(file)
+    d3 = audobject.load_from_yaml(file)
     print(d3)
 
 Parameters
@@ -1034,7 +1034,7 @@ Last but not least, we can read/write the parameters from/to a file.
 
     file = 'params.yaml'
     params.to_yaml(file)
-    params2 = audobject.Object.from_yaml(file)
+    params2 = audobject.load_from_yaml(file)
     print(params2)
 
 .. reset working directory and clean up

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -23,10 +23,10 @@ import audobject.testing
 )
 def test(tmpdir, obj):
 
-    assert obj == audobject.Object.from_yaml_s(obj.to_yaml_s())
+    assert obj == audobject.load_from_yaml_s(obj.to_yaml_s())
     path = os.path.join(tmpdir, 'test.yaml')
     obj.to_yaml(path)
-    t2 = audobject.Object.from_yaml(path)
+    t2 = audobject.load_from_yaml(path)
     assert obj == t2
     assert repr(obj) == repr(t2)
     assert str(obj) == str(t2)
@@ -79,7 +79,7 @@ def test_borrowed():
     assert o.point.x == x
     assert o.point.y == y
     assert o.d['z'] == z
-    o2 = audobject.Object.from_yaml_s(o.to_yaml_s(include_version=False))
+    o2 = audobject.load_from_yaml_s(o.to_yaml_s(include_version=False))
     assert isinstance(o2, ObjectWithBorrowedArguments)
     assert x not in o2.__dict__
     assert y not in o2.__dict__
@@ -196,17 +196,17 @@ def test_hidden_attributes(tmpdir):
     assert o.hidden_child == 'hidden_child'
     assert o.hidden_parent == 'hidden_parent'
 
-    o2 = audobject.Object.from_yaml_s(o.to_yaml_s(include_version=False))
+    o2 = audobject.load_from_yaml_s(o.to_yaml_s(include_version=False))
     assert isinstance(o2, ChildWithHiddenArguments)
     assert o2.hidden_child is None
     assert o2.hidden_parent is None
 
     o.to_yaml(path, include_version=False)
-    o2 = audobject.Object.from_yaml(path)
+    o2 = audobject.load_from_yaml(path)
     assert isinstance(o2, ChildWithHiddenArguments)
     assert o2.hidden_child is None
 
-    o2 = audobject.Object.from_yaml_s(
+    o2 = audobject.load_from_yaml_s(
         o.to_yaml_s(include_version=False),
         hidden_child='hidden_child',
         hidden_parent='hidden_parent',
@@ -216,7 +216,7 @@ def test_hidden_attributes(tmpdir):
     assert o2.hidden_parent == 'hidden_parent'
 
     o.to_yaml(path, include_version=False)
-    o2 = audobject.Object.from_yaml(
+    o2 = audobject.load_from_yaml(
         path,
         hidden_child='hidden_child',
         hidden_parent='hidden_parent',
@@ -230,7 +230,7 @@ def test_override_attributes():
 
     o = audobject.testing.TestObject(name='name')
     assert o.name == 'name'
-    o2 = audobject.Object.from_yaml_s(
+    o2 = audobject.load_from_yaml_s(
         o.to_yaml_s(),
         name='override',
     )

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -23,10 +23,10 @@ import audobject.testing
 )
 def test(tmpdir, obj):
 
-    assert obj == audobject.load_from_yaml_s(obj.to_yaml_s())
+    assert obj == audobject.from_yaml_s(obj.to_yaml_s())
     path = os.path.join(tmpdir, 'test.yaml')
     obj.to_yaml(path)
-    t2 = audobject.load_from_yaml(path)
+    t2 = audobject.from_yaml(path)
     assert obj == t2
     assert repr(obj) == repr(t2)
     assert str(obj) == str(t2)
@@ -79,7 +79,7 @@ def test_borrowed():
     assert o.point.x == x
     assert o.point.y == y
     assert o.d['z'] == z
-    o2 = audobject.load_from_yaml_s(o.to_yaml_s(include_version=False))
+    o2 = audobject.from_yaml_s(o.to_yaml_s(include_version=False))
     assert isinstance(o2, ObjectWithBorrowedArguments)
     assert x not in o2.__dict__
     assert y not in o2.__dict__
@@ -196,17 +196,17 @@ def test_hidden_attributes(tmpdir):
     assert o.hidden_child == 'hidden_child'
     assert o.hidden_parent == 'hidden_parent'
 
-    o2 = audobject.load_from_yaml_s(o.to_yaml_s(include_version=False))
+    o2 = audobject.from_yaml_s(o.to_yaml_s(include_version=False))
     assert isinstance(o2, ChildWithHiddenArguments)
     assert o2.hidden_child is None
     assert o2.hidden_parent is None
 
     o.to_yaml(path, include_version=False)
-    o2 = audobject.load_from_yaml(path)
+    o2 = audobject.from_yaml(path)
     assert isinstance(o2, ChildWithHiddenArguments)
     assert o2.hidden_child is None
 
-    o2 = audobject.load_from_yaml_s(
+    o2 = audobject.from_yaml_s(
         o.to_yaml_s(include_version=False),
         hidden_child='hidden_child',
         hidden_parent='hidden_parent',
@@ -216,7 +216,7 @@ def test_hidden_attributes(tmpdir):
     assert o2.hidden_parent == 'hidden_parent'
 
     o.to_yaml(path, include_version=False)
-    o2 = audobject.load_from_yaml(
+    o2 = audobject.from_yaml(
         path,
         hidden_child='hidden_child',
         hidden_parent='hidden_parent',
@@ -230,7 +230,7 @@ def test_override_attributes():
 
     o = audobject.testing.TestObject(name='name')
     assert o.name == 'name'
-    o2 = audobject.load_from_yaml_s(
+    o2 = audobject.from_yaml_s(
         o.to_yaml_s(),
         name='override',
     )

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -205,5 +205,5 @@ def test_parameters_yaml(tmpdir):
     p = pytest.PARAMETERS
     file = os.path.join(tmpdir, 'params.yaml')
     p.to_yaml(file)
-    p2 = audobject.load_from_yaml(file)
+    p2 = audobject.from_yaml(file)
     assert p == p2

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -205,5 +205,5 @@ def test_parameters_yaml(tmpdir):
     p = pytest.PARAMETERS
     file = os.path.join(tmpdir, 'params.yaml')
     p.to_yaml(file)
-    p2 = audobject.Object.from_yaml(file)
+    p2 = audobject.load_from_yaml(file)
     assert p == p2

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -40,6 +40,6 @@ def test_filepath(tmpdir):
     new_yaml_path = os.path.join(new_root, 'yaml', 'object.yaml')
 
     # re-instantiate object from new location and assert path exists
-    o2 = audobject.Object.from_yaml(new_yaml_path)
+    o2 = audobject.load_from_yaml(new_yaml_path)
     assert isinstance(o2, ObjectWithFile)
     assert os.path.exists(o2.path)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -40,6 +40,6 @@ def test_filepath(tmpdir):
     new_yaml_path = os.path.join(new_root, 'yaml', 'object.yaml')
 
     # re-instantiate object from new location and assert path exists
-    o2 = audobject.load_from_yaml(new_yaml_path)
+    o2 = audobject.from_yaml(new_yaml_path)
     assert isinstance(o2, ObjectWithFile)
     assert os.path.exists(o2.path)

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -74,7 +74,7 @@ class MyObject(audobject.Object):
 
 
 with pytest.raises(RuntimeError):
-    audobject.Object.from_yaml_s(o_yaml)
+    audobject.load_from_yaml_s(o_yaml)
 
 
 audobject.config.SIGNATURE_MISMATCH_WARN_LEVEL = \

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -74,7 +74,7 @@ class MyObject(audobject.Object):
 
 
 with pytest.raises(RuntimeError):
-    audobject.load_from_yaml_s(o_yaml)
+    audobject.from_yaml_s(o_yaml)
 
 
 audobject.config.SIGNATURE_MISMATCH_WARN_LEVEL = \


### PR DESCRIPTION
Closes #15 

Deprecates the static `audobject.Object.from_*()` methods (with version 1.0.0) and introduces `audobject.from_*()` instead.
