### PR TITLE
Store package name if it does not match module

### DIFF
--- a/audobject/core/define.py
+++ b/audobject/core/define.py
@@ -2,6 +2,7 @@ import datetime
 
 
 OBJECT_TAG = '$'
+PACKAGE_TAG = ':'
 VERSION_TAG = '=='
 DEFAULT_VALUE_TYPES = (str, int, float, bool, datetime.datetime)
 CUSTOM_VALUE_RESOLVERS = '_object_resolvers_'

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -4,6 +4,7 @@ import os
 import typing
 import warnings
 
+from importlib_metadata import packages_distributions
 import oyaml as yaml
 
 import audeer
@@ -242,9 +243,17 @@ class Object:
             {'name': 'test', 'point.0': 1, 'point.1': 1}
 
         """  # noqa: E501
-        name = f'{define.OBJECT_TAG}' \
-               f'{self.__class__.__module__}.' \
-               f'{self.__class__.__name__}'
+        name = define.OBJECT_TAG
+
+        # store package name if it differs from module name
+        module_name = self.__class__.__module__.split('.')[0]
+        package_names = packages_distributions()
+        if module_name in package_names:
+            package_name = package_names[module_name][0]
+            if package_name != module_name:
+                name += f'{package_name}{define.PACKAGE_TAG}'
+
+        name += f'{self.__class__.__module__}.{self.__class__.__name__}'
 
         if include_version:
             version = utils.get_version(self.__class__.__module__)

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -4,7 +4,6 @@ import os
 import typing
 import warnings
 
-from importlib_metadata import packages_distributions
 import oyaml as yaml
 
 import audeer
@@ -243,28 +242,7 @@ class Object:
             {'name': 'test', 'point.0': 1, 'point.1': 1}
 
         """  # noqa: E501
-        name = define.OBJECT_TAG
-
-        # store package name if it differs from module name
-        module_name = self.__class__.__module__.split('.')[0]
-        package_names = packages_distributions()
-        if module_name in package_names:
-            package_name = package_names[module_name][0]
-            if package_name != module_name:
-                name += f'{package_name}{define.PACKAGE_TAG}'
-
-        name += f'{self.__class__.__module__}.{self.__class__.__name__}'
-
-        if include_version:
-            version = utils.get_version(self.__class__.__module__)
-            if version is not None:
-                name += f'{define.VERSION_TAG}{version}'
-            else:
-                warnings.warn(
-                    f"Could not determine a version for "
-                    f"module '{self.__class__.__module__}'.",
-                    RuntimeWarning,
-                )
+        name = utils.create_class_key(self, include_version)
 
         d = {
             key: self._encode_variable(

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -242,7 +242,7 @@ class Object:
             {'name': 'test', 'point.0': 1, 'point.1': 1}
 
         """  # noqa: E501
-        name = utils.create_class_key(self, include_version)
+        name = utils.create_class_key(self.__class__, include_version)
 
         d = {
             key: self._encode_variable(

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -179,5 +179,8 @@ def split_key(key: str) -> [str, str, str, typing.Optional[str]]:
     tokens = key.split('.')
     module_name = '.'.join(tokens[:-1])
     class_name = tokens[-1]
-    package_name = module_name.split('.')[0]
+    if define.PACKAGE_TAG in module_name:
+        package_name = module_name.split(define.PACKAGE_TAG)[0]
+    else:
+        package_name = module_name.split('.')[0]
     return package_name, module_name, class_name, version

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -10,8 +10,8 @@ from importlib_metadata import packages_distributions
 
 import audeer
 
-from audobject.core.config import config
 from audobject.core import define
+from audobject.core.config import config
 
 
 def create_class_key(cls: type, include_version: bool) -> str:

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -15,8 +15,19 @@ from audobject.core import define
 
 
 def create_class_key(cls: type, include_version: bool) -> str:
-    r"""Create class key."""
+    r"""Create class key.
 
+    Convert class into a string that encodes
+    package, module, class name and possibly version.
+    Package name is ommited if it matches the module.
+
+    Examples:
+
+    - $audeer.core.version.LooseVersion
+    - $audeer.core.version.LooseVersion==1.18.0
+    - $PyYAML:yaml.loader.Loader
+
+    """
     key = define.OBJECT_TAG
 
     # add package name (if different from module name)
@@ -50,8 +61,6 @@ def get_class(
         auto_install: bool,
 ) -> (type, str, str):
     r"""Load class."""
-    if key.startswith(define.OBJECT_TAG):
-        key = key[len(define.OBJECT_TAG):]
     package_name, module_name, class_name, version = split_class_key(key)
     module = get_module(
         package_name,
@@ -205,9 +214,21 @@ def is_class(value: typing.Any):
 
 
 def split_class_key(key: str) -> [str, str, str, typing.Optional[str]]:
-    r"""Split class key into package, module, class and version."""
+    r"""Split class key into package, module, class and version.
 
+    Expects a key in the format output by create_class_key().
+    If package is not encoded,
+    the module name is returned.
+    If version is not encoded,
+    None is returned.
+    Leading $ can be omitted.
+
+    """
     version = None
+
+    # possibly remove leading $
+    if key.startswith(define.OBJECT_TAG):
+        key = key[len(define.OBJECT_TAG):]
 
     # split off version (if available)
     if define.VERSION_TAG in key:

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -19,7 +19,7 @@ def create_class_key(cls: type, include_version: bool) -> str:
     key = define.OBJECT_TAG
 
     # store package name if it differs from module name
-    module_name = cls.__class__.__module__.split('.')[0]
+    module_name = cls.__module__.split('.')[0]
     package_names = packages_distributions()
     if module_name in package_names:
         package_name = package_names[module_name][0]
@@ -27,17 +27,17 @@ def create_class_key(cls: type, include_version: bool) -> str:
             key += f'{package_name}{define.PACKAGE_TAG}'
 
     # add module and class name
-    key += f'{cls.__class__.__module__}.{cls.__class__.__name__}'
+    key += f'{cls.__module__}.{cls.__name__}'
 
     # add version
     if include_version:
-        version = get_version(cls.__class__.__module__)
+        version = get_version(cls.__module__)
         if version is not None:
             key += f'{define.VERSION_TAG}{version}'
         else:
             warnings.warn(
                 f"Could not determine a version for "
-                f"module '{cls.__class__.__module__}'.",
+                f"module '{cls.__module__}'.",
                 RuntimeWarning,
             )
 

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -16,9 +16,10 @@ from audobject.core import define
 
 def create_class_key(cls: type, include_version: bool) -> str:
     r"""Create class key."""
+
     key = define.OBJECT_TAG
 
-    # store package name if it differs from module name
+    # add package name (if different from module name)
     module_name = cls.__module__.split('.')[0]
     package_names = packages_distributions()
     if module_name in package_names:
@@ -29,7 +30,7 @@ def create_class_key(cls: type, include_version: bool) -> str:
     # add module and class name
     key += f'{cls.__module__}.{cls.__name__}'
 
-    # add version
+    # add version (if requested)
     if include_version:
         version = get_version(cls.__module__)
         if version is not None:
@@ -204,16 +205,26 @@ def is_class(value: typing.Any):
 
 
 def split_class_key(key: str) -> [str, str, str, typing.Optional[str]]:
-    r"""Split class key in package, module, class and version."""
+    r"""Split class key into package, module, class and version."""
+
     version = None
+
+    # split off version (if available)
     if define.VERSION_TAG in key:
         key, version = key.split(define.VERSION_TAG)
+
+    # split off package (if available)
     package_name = None
     if define.PACKAGE_TAG in key:
         package_name, key = key.split(define.PACKAGE_TAG)
+
+    # split off module and class name
     tokens = key.split('.')
     module_name = '.'.join(tokens[:-1])
     class_name = tokens[-1]
+
+    # if package name not given, set to module name
     if package_name is None:
         package_name = tokens[0]
+
     return package_name, module_name, class_name, version

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -176,11 +176,12 @@ def split_key(key: str) -> [str, str, str, typing.Optional[str]]:
     version = None
     if define.VERSION_TAG in key:
         key, version = key.split(define.VERSION_TAG)
+    package_name = None
+    if define.PACKAGE_TAG in key:
+        package_name, key = key.split(define.PACKAGE_TAG)
     tokens = key.split('.')
     module_name = '.'.join(tokens[:-1])
     class_name = tokens[-1]
-    if define.PACKAGE_TAG in module_name:
-        package_name = module_name.split(define.PACKAGE_TAG)[0]
-    else:
-        package_name = module_name.split('.')[0]
+    if package_name is None:
+        package_name = tokens[0]
     return package_name, module_name, class_name, version

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.18.0
+    importlib-metadata >=4.8.0  # can be replaced with 'importlib.metadata' once we drop support for Python 3.6 / 3.7
     oyaml
 setup_requires =
     setuptools_scm

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 parse
-pip-autoremove
 pytest<7.0.0
 pytest-flake8
 pytest-doctestplus

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 parse
+pip-autoremove
 pytest<7.0.0
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -16,7 +16,13 @@ ${PACKAGE}.core.filesystem.FileSystem==0.3.12:
 '''
 
 yaml_without_version = f'''
-{PACKAGE}.core.filesystem.FileSystem:
+${PACKAGE}.core.filesystem.FileSystem:
+  host: ~/host
+  repository: repo
+'''
+
+yaml_with_package = f'''
+${PACKAGE}:{PACKAGE}.core.filesystem.FileSystem:
   host: ~/host
   repository: repo
 '''
@@ -49,6 +55,7 @@ def run_around_tests():
     [
         yaml_with_version,
         yaml_without_version,
+        yaml_with_package,
     ],
 )
 def test(yaml_s):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,10 +11,13 @@ def uninstall(
     package: str,
     module: str,
 ):
-    # uninstall package and dependencies
+    # uninstall package
     subprocess.check_call(
         [
-            'pip-autoremove',
+            sys.executable,
+            '-m',
+            'pip',
+            'uninstall',
             '--yes',
             package,
         ]

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -93,32 +93,44 @@ def test_borrowed():
 
 
 @pytest.mark.parametrize(
-    'cls, include_version, expected',
+    'cls, package, include_version, expected',
     [
         (
             audeer.LooseVersion,
+            'audeer',
             False,
             '$audeer.core.version.LooseVersion',
         ),
         (
             audeer.LooseVersion,
+            'audeer',
             True,
             f'$audeer.core.version.LooseVersion=={audeer.__version__}',
         ),
         (
             yaml.Loader,
+            'PyYAML',
             False,
             '$PyYAML:yaml.loader.Loader',
         ),
         (
             yaml.Loader,
+            'PyYAML',
             True,
             f'$PyYAML:yaml.loader.Loader=={yaml.__version__}',
         ),
     ]
 )
-def test_create_class_key(cls, include_version, expected):
-    assert utils.create_class_key(cls, include_version) == expected
+def test_class_key(cls, package, include_version, expected):
+    key = utils.create_class_key(cls, include_version)
+    assert key == expected
+    p, m, c, v = utils.split_class_key(key[1:])
+    if include_version:
+        assert expected.endswith(f'{m}.{c}=={v}')
+    else:
+        assert v is None
+        assert expected.endswith(f'{m}.{c}')
+    assert p == package
 
 
 @pytest.mark.parametrize(

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -124,7 +124,7 @@ def test_borrowed():
 def test_class_key(cls, package, include_version, expected):
     key = utils.create_class_key(cls, include_version)
     assert key == expected
-    p, m, c, v = utils.split_class_key(key[1:])
+    p, m, c, v = utils.split_class_key(key)
     if include_version:
         assert expected.endswith(f'{m}.{c}=={v}')
     else:

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,9 +1,12 @@
 import os
 
+import audeer
+import yaml
 import pytest
 
 import audobject
 import audobject.testing
+import audobject.core.utils as utils
 
 
 @pytest.mark.parametrize(
@@ -87,6 +90,35 @@ def test_borrowed():
     assert o2.point.x == x
     assert o2.point.y == y
     assert o.d['z'] == z
+
+
+@pytest.mark.parametrize(
+    'cls, include_version, expected',
+    [
+        (
+            audeer.LooseVersion,
+            False,
+            '$audeer.core.version.LooseVersion',
+        ),
+        (
+            audeer.LooseVersion,
+            True,
+            f'$audeer.core.version.LooseVersion=={audeer.__version__}',
+        ),
+        (
+            yaml.Loader,
+            False,
+            '$PyYAML:yaml.loader.Loader',
+        ),
+        (
+            yaml.Loader,
+            True,
+            f'$PyYAML:yaml.loader.Loader=={yaml.__version__}',
+        ),
+    ]
+)
+def test_create_class_key(cls, include_version, expected):
+    assert utils.create_class_key(cls, include_version) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,12 +1,12 @@
 import os
 
-import audeer
-import yaml
 import pytest
+import yaml
 
+import audeer
 import audobject
-import audobject.testing
 import audobject.core.utils as utils
+import audobject.testing
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #36 

In case module and package name do not match the class key is now extended from `$<module>.<class>==version` to `$<package>:<module>.<class>==version`. This is handled by a new internal utility function `utils.create_class_key()`. The function `utils.split_class_key()`, which takes care of splitting the key, will return the module name as package name if no explicit package name is given.