### PR TITLE
Remove deprecation warning from init_decorator()

### DIFF
--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -8,11 +8,6 @@ from audobject.core import define
 from audobject.core import resolver
 
 
-@audeer.deprecated_keyword_argument(
-    deprecated_argument='ignore_vars',
-    removal_version='0.5.0',
-    new_argument='hide',
-)
 def init_decorator(
         *,
         borrow: typing.Dict[str, str] = None,


### PR DESCRIPTION
Seems there was a deprecation warning left over.
I couldn't find any part of the code that needs to be changed, so I just removed the warning.