### PR TITLE
Remove deprecated kwargs from object loading

### DIFF
--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -8,20 +8,12 @@ from audobject.core.object import Object
 import audobject.core.utils as utils
 
 
-kwargs_deprecation_warning = (
-    "The use of **kwargs is deprecated "
-    "and will be removed with version 1.0.0. "
-    "Use 'override_args' instead."
-)
-
-
 def from_dict(
         d: typing.Dict[str, typing.Any],
         root: str = None,
         *,
         auto_install: bool = False,
         override_args: typing.Dict[str, typing.Any] = None,
-        **kwargs,
 ) -> 'Object':
     r"""Create object from dictionary.
 
@@ -42,15 +34,6 @@ def from_dict(
 
     """
     override_args = override_args or {}
-
-    if kwargs:
-        warnings.warn(
-            kwargs_deprecation_warning,
-            category=UserWarning,
-            stacklevel=2,
-        )
-        for key, value in kwargs.items():
-            override_args[key] = value
 
     name = next(iter(d))
     cls, version, installed_version = utils.get_class(
@@ -75,7 +58,6 @@ def from_yaml(
         *,
         auto_install: bool = False,
         override_args: typing.Dict[str, typing.Any] = None,
-        **kwargs,
 ) -> 'Object':
     r"""Create object from YAML file.
 
@@ -91,15 +73,6 @@ def from_yaml(
 
     """
     override_args = override_args or {}
-
-    if kwargs:
-        warnings.warn(
-            kwargs_deprecation_warning,
-            category=UserWarning,
-            stacklevel=2,
-        )
-        for key, value in kwargs.items():
-            override_args[key] = value
 
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
@@ -117,7 +90,6 @@ def from_yaml_s(
         *,
         auto_install: bool = False,
         override_args: typing.Dict[str, typing.Any] = None,
-        **kwargs,
 ) -> 'Object':
     r"""Create object from YAML string.
 
@@ -133,15 +105,6 @@ def from_yaml_s(
 
     """
     override_args = override_args or {}
-
-    if kwargs:
-        warnings.warn(
-            kwargs_deprecation_warning,
-            category=UserWarning,
-            stacklevel=2,
-        )
-        for key, value in kwargs.items():
-            override_args[key] = value
 
     return from_dict(
         yaml.load(yaml_string, yaml.Loader),

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -343,53 +343,6 @@ def test_override_attributes(tmpdir):
     assert o6.root == 'override'
 
 
-def test_override_attributes_deprecated(tmpdir):
-
-    o = audobject.testing.TestObject(
-        name='name',
-    )
-    assert o.name == 'name'
-
-    with pytest.warns(UserWarning):
-        o1 = audobject.from_dict(
-            o.to_dict(include_version=False),
-            name='override',
-        )
-    assert isinstance(o1, audobject.testing.TestObject)
-    assert o1.name == 'override'
-
-    with pytest.warns(UserWarning):
-        o2 = audobject.from_yaml_s(
-            o.to_yaml_s(include_version=False),
-            name='override',
-        )
-    assert isinstance(o2, audobject.testing.TestObject)
-    assert o2.name == 'override'
-
-    # override argument named root
-
-    o3 = ArgumentWithNameRoot()
-    assert o3.root is None
-
-    with pytest.warns(UserWarning):
-        o4 = audobject.from_yaml_s(
-            o3.to_yaml_s(include_version=False),
-            root='override',
-        )
-    assert isinstance(o4, ArgumentWithNameRoot)
-    assert o4.root == 'override'
-
-    path = os.path.join(tmpdir, 'object.yaml')
-    o3.to_yaml(path, include_version=False)
-    with pytest.warns(UserWarning):
-        o5 = audobject.from_yaml(
-            path,
-            root='override',
-        )
-    assert isinstance(o5, ArgumentWithNameRoot)
-    assert o5.root == 'override'
-
-
 def test_no_resolver():
 
     obj = audobject.testing.TestObject(


### PR DESCRIPTION
If we target 1.0.0 as next version we should start and remove all the deprecated code that we promised to remove with version 1.0.0.

I would do it in single pull request to have a commit for each deprecated argument/function/class.