### PR TITLE
Remove deprecated audobject.ValueResolver

### DIFF
--- a/audobject/__init__.py
+++ b/audobject/__init__.py
@@ -23,7 +23,6 @@ from audobject.core.resolver import (
     FunctionResolver,
     TupleResolver,
     TypeResolver,
-    ValueResolver,
 )
 
 

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -30,9 +30,9 @@ def init_decorator(
     Note that objects you borrow attributes from, are also treated as
     hidden arguments.
 
-    If a dictionary of :class:`audobject.ValueResolver` is passed,
+    If a dictionary of :class:`audobject.resolver.Base` is passed,
     matching attributes will be encoded / decoded
-    using the according :class:`audobject.ValueResolver`.
+    using the according :class:`audobject.resolver.Base`.
 
     Args:
         borrow: borrowed attributes

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -30,9 +30,10 @@ def init_decorator(
     Note that objects you borrow attributes from, are also treated as
     hidden arguments.
 
-    If a dictionary of :class:`audobject.resolver.Base` is passed,
-    matching attributes will be encoded / decoded
-    using the according :class:`audobject.resolver.Base`.
+    To control how arguments are encoded / decoded,
+    a dictionary of resolvers can be passed.
+    The dictionary maps argument names
+    to resolver classes derived from :class:`audobject.resolver.Base`.
 
     Args:
         borrow: borrowed attributes

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -478,39 +478,6 @@ class Type(Base):
 
 # deprecated classes
 
-
-# @audeer.deprecated(
-#     removal_version='1.0.0',
-#     alternative='resolver.Base',
-# )
-# ->
-# TypeError: function() argument 1 must be code, not str
-# ->
-# as a workaround we raise the deprecation warning in __init__
-class ValueResolver:  # pragma: no cover
-
-    def __init__(self):
-        message = (
-            'ValueResolver is deprecated and will be removed '
-            'with version 1.0.0. Use resolver.Base instead.'
-        )
-        warnings.warn(message, category=UserWarning, stacklevel=2)
-        self.__dict__[define.ROOT_ATTRIBUTE] = None
-
-    @property
-    def root(self) -> typing.Optional[str]:
-        return self.__dict__[define.ROOT_ATTRIBUTE]
-
-    def decode(self, value: DefaultValueType) -> typing.Any:
-        raise NotImplementedError
-
-    def encode(self, value: typing.Any) -> DefaultValueType:
-        raise NotImplementedError
-
-    def encode_type(self) -> type:
-        raise NotImplementedError
-
-
 @audeer.deprecated(
     removal_version='1.0.0',
     alternative='resolver.Function',


### PR DESCRIPTION
Removes deprecated `audobject.ValueResolver`.

It was also still mentioned in the documentation:

![image](https://user-images.githubusercontent.com/173624/159021575-b0add53a-0fbe-4dde-b6ff-4299ba61e634.png)
