### PR TITLE
Fix: poperly pass on auto_install argument

### DIFF
--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -76,7 +76,11 @@ def from_yaml(
 
     if isinstance(path_or_stream, str):
         with open(path_or_stream, 'r') as fp:
-            return from_yaml(fp, override_args=override_args)
+            return from_yaml(
+                fp,
+                override_args=override_args,
+                auto_install=auto_install,
+            )
     return from_dict(
         yaml.load(path_or_stream, yaml.Loader),
         auto_install=auto_install,

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -42,7 +42,11 @@ def from_dict(
     )
     params = {}
     for key, value in d[name].items():
-        params[key] = _decode_value(value, override_args)
+        params[key] = _decode_value(
+            value,
+            auto_install,
+            override_args,
+        )
     return utils.get_object(
         cls,
         version,
@@ -119,21 +123,33 @@ def from_yaml_s(
 
 def _decode_value(
         value_to_decode: typing.Any,
+        auto_install: bool,
         override_args: typing.Dict[str, typing.Any],
 ) -> typing.Any:
     r"""Decode value."""
     if value_to_decode:  # not empty
         if isinstance(value_to_decode, list):
             return [
-                _decode_value(v, override_args) for v in value_to_decode
+                _decode_value(
+                    v,
+                    auto_install,
+                    override_args,
+                ) for v in value_to_decode
             ]
         elif isinstance(value_to_decode, dict):
             name = next(iter(value_to_decode))
             if isinstance(name, Object) or utils.is_class(name):
-                return from_dict(value_to_decode, override_args=override_args)
+                return from_dict(
+                    value_to_decode,
+                    auto_install=auto_install,
+                    override_args=override_args,
+                )
             else:
                 return {
-                    k: _decode_value(v, override_args) for k, v in
-                    value_to_decode.items()
+                    k: _decode_value(
+                        v,
+                        auto_install,
+                        override_args,
+                    ) for k, v in value_to_decode.items()
                 }
     return value_to_decode

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,10 +37,10 @@ setup_requires =
 addopts =
     --flake8
     --doctest-plus
-;    --cov=audobject
-;    --cov-fail-under=100
-;    --cov-report xml
-;    --cov-report term-missing
+    --cov=audobject
+    --cov-fail-under=100
+    --cov-report xml
+    --cov-report term-missing
 xfail_strict = true
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,10 +37,10 @@ setup_requires =
 addopts =
     --flake8
     --doctest-plus
-    --cov=audobject
-    --cov-fail-under=100
-    --cov-report xml
-    --cov-report term-missing
+;    --cov=audobject
+;    --cov-fail-under=100
+;    --cov-report xml
+;    --cov-report term-missing
 xfail_strict = true
 
 [flake8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,4 +65,5 @@ def uninstall(
 def cleanup():
     yield
     # uninstall package temporarily installed by test_install.py
+    uninstall('audbackend', 'audbackend')
     uninstall('dohq-artifactory', 'artifactory')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def uninstall(
     )
     # remove module
     for m in list(sys.modules):
-        if m.startswith(package):
+        if m.startswith(module):
             sys.modules.pop(m)
     # force pkg_resources to re-scan site packages
     pkg_resources._initialize_master_working_set()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -12,26 +12,26 @@ from conftest import uninstall
     [
         (  # package and module do not match
             '''
-$dohq-artifactory:artifactory.ArtifactoryPath:
-  token: token
+            $dohq-artifactory:artifactory.ArtifactoryPath:
+              token: token
             ''',
             'dohq-artifactory',
             'artifactory',
         ),
         (  # package and module match
             '''
-$audbackend.core.filesystem.FileSystem:
-  host: ~/host
-  repository: repo
+            $audbackend.core.filesystem.FileSystem:
+              host: ~/host
+              repository: repo
             ''',
             'audbackend',
             'audbackend',
         ),
         (  # with package version
             '''
-$audbackend.core.filesystem.FileSystem==0.3.12:
-  host: ~/host
-  repository: repo
+            $audbackend.core.filesystem.FileSystem==0.3.12:
+              host: ~/host
+              repository: repo
             ''',
             'audbackend',
             'audbackend',

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -27,15 +27,17 @@ from conftest import uninstall
             'audbackend',
             'audbackend',
         ),
-        (  # with package version
-            '''
-            $audbackend.core.filesystem.FileSystem==0.3.12:
-              host: ~/host
-              repository: repo
+        (  # with package version and as nested object
+            '''$audobject.core.testing.TestObject:
+              name: test
+              backend:
+                $audbackend.core.filesystem.FileSystem==0.3.12:
+                  host: ~/host
+                  repository: repo
             ''',
             'audbackend',
             'audbackend',
-        ),
+        )
     ],
 )
 def test(tmpdir, yaml_s, package, module):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -12,26 +12,26 @@ from conftest import uninstall
     [
         (  # package and module do not match
             '''
-            $dohq-artifactory:artifactory.ArtifactoryPath:
-              token: token
+$dohq-artifactory:artifactory.ArtifactoryPath:
+  token: token
             ''',
             'dohq-artifactory',
             'artifactory',
         ),
         (  # package and module match
             '''
-            $audbackend.core.filesystem.FileSystem:
-              host: ~/host
-              repository: repo
+$audbackend.core.filesystem.FileSystem:
+  host: ~/host
+  repository: repo
             ''',
             'audbackend',
             'audbackend',
         ),
         (  # with package version
             '''
-            $audbackend.core.filesystem.FileSystem==0.3.12:
-              host: ~/host
-              repository: repo
+$audbackend.core.filesystem.FileSystem==0.3.12:
+  host: ~/host
+  repository: repo
             ''',
             'audbackend',
             'audbackend',
@@ -40,6 +40,26 @@ from conftest import uninstall
 )
 def test(tmpdir, yaml_s, package, module):
 
+    # fails because of missing packages
+    with pytest.raises(ModuleNotFoundError):
+        audobject.from_yaml_s(
+            yaml_s,
+            auto_install=False,
+        )
+    # install missing packages
+    audobject.from_yaml_s(
+        yaml_s,
+        auto_install=True,
+    )
+    # still works when packages are installed
+    audobject.from_yaml_s(
+        yaml_s,
+        auto_install=True,
+    )
+    # uninstall package
+    uninstall(package, module)
+
+    # repeat, but this time test from file
     path = os.path.join(tmpdir, 'tmp.yaml')
     with open(path, 'w') as fp:
         fp.write(yaml_s)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import audobject
@@ -36,21 +38,26 @@ from conftest import uninstall
         ),
     ],
 )
-def test(yaml_s, package, module):
+def test(tmpdir, yaml_s, package, module):
+
+    path = os.path.join(tmpdir, 'tmp.yaml')
+    with open(path, 'w') as fp:
+        fp.write(yaml_s)
+
     # fails because of missing packages
     with pytest.raises(ModuleNotFoundError):
-        audobject.from_yaml_s(
-            yaml_s,
+        audobject.from_yaml(
+            path,
             auto_install=False,
         )
     # install missing packages
-    audobject.from_yaml_s(
-        yaml_s,
+    audobject.from_yaml(
+        path,
         auto_install=True,
     )
     # still works when packages are installed
-    audobject.from_yaml_s(
-        yaml_s,
+    audobject.from_yaml(
+        path,
         auto_install=True,
     )
     # uninstall package


### PR DESCRIPTION
In our tests with `auto_install=True` we forgot to cover `to_yaml()`, which basically relies on `to_yaml_s()`, but unfortunately, we do not pass on the argument at the moment. This fixes the bug and extends the test to cover it.