### PR TITLE
Fix: properly serialize keyword arguments

### DIFF
--- a/audobject/core/define.py
+++ b/audobject/core/define.py
@@ -1,14 +1,15 @@
 import datetime
 
 
+BORROWED_ATTRIBUTES = '_object_borrowed_'
+CUSTOM_VALUE_RESOLVERS = '_object_resolvers_'
+DEFAULT_VALUE_TYPES = (str, int, float, bool, datetime.datetime)
+HIDDEN_ATTRIBUTES = '_object_hidden_'
+KEYWORD_ARGUMENTS = '_object_kwargs_'
 OBJECT_TAG = '$'
 PACKAGE_TAG = ':'
-VERSION_TAG = '=='
-DEFAULT_VALUE_TYPES = (str, int, float, bool, datetime.datetime)
-CUSTOM_VALUE_RESOLVERS = '_object_resolvers_'
-BORROWED_ATTRIBUTES = '_object_borrowed_'
-HIDDEN_ATTRIBUTES = '_object_hidden_'
 ROOT_ATTRIBUTE = '_object_root_'
+VERSION_TAG = '=='
 
 
 class PackageMismatchWarnLevel:

--- a/audobject/core/dictionary.py
+++ b/audobject/core/dictionary.py
@@ -73,12 +73,7 @@ class Dictionary(Object):
         r"""Return self.__dict__ without special attributes"""
         d = {}
         for key, value in self.__dict__.items():
-            if key not in [
-                define.BORROWED_ATTRIBUTES,
-                define.CUSTOM_VALUE_RESOLVERS,
-                define.HIDDEN_ATTRIBUTES,
-                define.KEYWORD_ARGUMENTS,
-            ]:
+            if key != define.KEYWORD_ARGUMENTS:
                 d[key] = value
         return d
 

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -52,7 +52,7 @@ class Object:
         """  # noqa: E501
         signature = inspect.signature(self.__init__)
 
-        # regular arguments from __init__
+        # non-keyword arguments from __init__
         names = [p.name for p in signature.parameters.values()
                  if not p.name == 'kwargs']
 

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -26,6 +26,12 @@ class Object:
           bar: hello object!
 
     """
+    def __init__(
+            self,
+            **kwargs,
+    ):
+        self.__dict__[define.KEYWORD_ARGUMENTS] = list(kwargs)
+
     @property
     def arguments(self) -> typing.Dict[str, typing.Any]:
         r"""Returns arguments that are serialized.
@@ -46,12 +52,13 @@ class Object:
         """  # noqa: E501
         signature = inspect.signature(self.__init__)
 
-        # if 'kwargs' are allowed, check all members
-        # otherwise only arguments from __init__
-        if 'kwargs' in signature.parameters:
-            names = self.__dict__
-        else:
-            names = [p.name for p in signature.parameters.values()]
+        # regular arguments from __init__
+        names = [p.name for p in signature.parameters.values()
+                 if not p.name == 'kwargs']
+
+        # additional keyword arguments
+        if define.KEYWORD_ARGUMENTS in self.__dict__:
+            names.extend(self.__dict__[define.KEYWORD_ARGUMENTS])
 
         # remove hidden and borrowed attributes
         borrowed = self.borrowed_arguments

--- a/audobject/core/testing.py
+++ b/audobject/core/testing.py
@@ -41,6 +41,8 @@ class TestObject(Object):
             point: (int, int) = (0, 0),
             **kwargs,
     ):
+        super().__init__(**kwargs)
+
         self.name = name
         self.point = point
         for key, value in kwargs.items():

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,0 +1,17 @@
+import audobject
+
+
+def test_dictionary():
+
+    kwargs = {
+        'foo': 'foo',
+        'bar': 'bar',
+    }
+    d = audobject.Dictionary(**kwargs)
+
+    assert audobject.core.define.KEYWORD_ARGUMENTS in d.__dict__
+    assert audobject.core.define.KEYWORD_ARGUMENTS not in d.arguments
+
+    assert kwargs == dict(d.items())
+    assert list(kwargs.keys()) == list(d.keys())
+    assert list(kwargs.values()) == list(d.values())

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -516,3 +516,36 @@ def test_bad_object():
     with pytest.raises(RuntimeError):
         with pytest.warns(RuntimeWarning):
             BadObject(0, 1).to_yaml_s()  # cannot borrow missing attribute
+
+
+class MyObjectWithKwargs(audobject.Object):
+
+    def __init__(
+            self,
+            arg: str,
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.arg = arg
+        self.no_arg = 'no arg'
+        for key, value in kwargs.items():
+            self.__dict__[key] = value
+
+
+def test_kwargs_object():
+
+    o = MyObjectWithKwargs(
+        'arg',
+        foo='foo',
+        bar='bar',
+    )
+    
+    assert 'arg' in o.arguments
+    assert 'foo' in o.arguments
+    assert 'bar' in o.arguments
+    assert 'no_arg' not in o.arguments
+    
+    o2 = audobject.from_yaml_s(o.to_yaml_s())
+    
+    assert o == o2

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -540,12 +540,12 @@ def test_kwargs_object():
         foo='foo',
         bar='bar',
     )
-    
+
     assert 'arg' in o.arguments
     assert 'foo' in o.arguments
     assert 'bar' in o.arguments
     assert 'no_arg' not in o.arguments
-    
+
     o2 = audobject.from_yaml_s(o.to_yaml_s())
-    
+
     assert o == o2

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -571,3 +571,32 @@ def test_kwargs_object():
 
     assert o == o2
     assert o2.hide_arg is None
+
+
+class MyObjectWithDeprecatedKwargs(audobject.Object):
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='deprecate_arg',
+        removal_version='999.9.9',
+    )
+    def __init__(
+            self,
+            arg: str,
+            *,
+            kwarg: str,
+            **kwargs,
+    ):
+        self.arg = arg
+        self.kwarg = kwarg
+
+
+def test_deprecated_kwargs_object():
+
+    with pytest.warns(UserWarning):
+        o = MyObjectWithDeprecatedKwargs(
+            'arg',
+            kwarg='kwarg',
+            deprecate_arg='deprecate',
+        )
+
+    assert 'deprecate_arg' not in o.arguments

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -532,6 +532,8 @@ class MyObjectWithKwargs(audobject.Object):
     def __init__(
             self,
             arg: str,
+            *,
+            kwarg: str,
             **kwargs,
     ):
         super().__init__(**kwargs)

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -529,6 +529,10 @@ class MyObjectWithKwargs(audobject.Object):
             'resolve_arg': audobject.resolver.Tuple,
         }
     )
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='deprecate_arg',
+        removal_version='999.9.9',
+    )
     def __init__(
             self,
             arg: str,
@@ -550,16 +554,19 @@ class MyObjectWithKwargs(audobject.Object):
 
 def test_kwargs_object():
 
-    o = MyObjectWithKwargs(
-        'arg',
-        borrow_arg='borrow',
-        hide_arg='hide',
-        kwarg='kwarg',
-        resolve_arg=('foo', 'bar'),
-        unassign_arg='unassign',
-    )
+    with pytest.warns(UserWarning, match='deprecate'):
+        o = MyObjectWithKwargs(
+            'arg',
+            borrow_arg='borrow',
+            deprecate_arg='deprecate',
+            hide_arg='hide',
+            kwarg='kwarg',
+            resolve_arg=('foo', 'bar'),
+            unassign_arg='unassign',
+        )
 
     assert 'borrow_arg' in o.arguments
+    assert 'deprecate_arg' not in o.arguments
     assert 'hide_arg' not in o.arguments
     assert 'kwarg' in o.arguments
     assert 'no_arg' not in o.arguments
@@ -571,32 +578,3 @@ def test_kwargs_object():
 
     assert o == o2
     assert o2.hide_arg is None
-
-
-class MyObjectWithDeprecatedKwargs(audobject.Object):
-
-    @audeer.deprecated_keyword_argument(
-        deprecated_argument='deprecate_arg',
-        removal_version='999.9.9',
-    )
-    def __init__(
-            self,
-            arg: str,
-            *,
-            kwarg: str,
-            **kwargs,
-    ):
-        self.arg = arg
-        self.kwarg = kwarg
-
-
-def test_deprecated_kwargs_object():
-
-    with pytest.warns(UserWarning):
-        o = MyObjectWithDeprecatedKwargs(
-            'arg',
-            kwarg='kwarg',
-            deprecate_arg='deprecate',
-        )
-
-    assert 'deprecate_arg' not in o.arguments

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -520,6 +520,15 @@ def test_bad_object():
 
 class MyObjectWithKwargs(audobject.Object):
 
+    @audobject.init_decorator(
+        borrow={
+            'borrow_arg': 'dict',
+        },
+        hide=['hide_arg', 'unassign_arg'],
+        resolvers={
+            'resolve_arg': audobject.resolver.Tuple,
+        }
+    )
     def __init__(
             self,
             arg: str,
@@ -528,24 +537,35 @@ class MyObjectWithKwargs(audobject.Object):
         super().__init__(**kwargs)
 
         self.arg = arg
-        self.no_arg = 'no arg'
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        self.kwarg = kwargs['kwarg']
+        self.dict = {
+            'borrow_arg': kwargs['borrow_arg']
+        }
+        self.no_arg = None
+        self.hide_arg = kwargs['hide_arg'] if 'hide_arg' in kwargs else None
+        self.resolve_arg = kwargs['resolve_arg']
 
 
 def test_kwargs_object():
 
     o = MyObjectWithKwargs(
         'arg',
-        foo='foo',
-        bar='bar',
+        borrow_arg='borrow',
+        hide_arg='hide',
+        kwarg='kwarg',
+        resolve_arg=('foo', 'bar'),
+        unassign_arg='unassign',
     )
 
-    assert 'arg' in o.arguments
-    assert 'foo' in o.arguments
-    assert 'bar' in o.arguments
+    assert 'borrow_arg' in o.arguments
+    assert 'hide_arg' not in o.arguments
+    assert 'kwarg' in o.arguments
     assert 'no_arg' not in o.arguments
+    assert 'resolve_arg' in o.arguments
 
-    o2 = audobject.from_yaml_s(o.to_yaml_s())
+    assert o.hide_arg is not None
+
+    o2 = audobject.from_yaml_s(o.to_yaml_s(include_version=False))
 
     assert o == o2
+    assert o2.hide_arg is None

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -539,7 +539,7 @@ class MyObjectWithKwargs(audobject.Object):
         super().__init__(**kwargs)
 
         self.arg = arg
-        self.kwarg = kwargs['kwarg']
+        self.kwarg = kwarg
         self.dict = {
             'borrow_arg': kwargs['borrow_arg']
         }


### PR DESCRIPTION
Fixes #50 

Instead of serializing all attributes to YAML, we only store the attributes that are actually passed as keyword arguments. Therefore, we pass `kwargs` to the constructor of the base class.

![image](https://user-images.githubusercontent.com/10383417/179523189-7b8c8180-8afb-4698-8936-65a768771217.png)
