### PR TITLE
Fix: set is_loaded_from_dict before calling __init__()

### DIFF
--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -66,7 +66,7 @@ def from_dict(
             override_args,
         )
 
-    object = utils.get_object(
+    object, params = utils.get_object(
         cls,
         version,
         installed_version,
@@ -78,6 +78,14 @@ def from_dict(
     if isinstance(object, Object):
         # create attribute to signal that object was loaded
         object.__dict__[define.OBJECT_LOADED] = None
+
+    # call __init__()
+    try:
+        params[define.ROOT_ATTRIBUTE] = root
+        object.__init__(**params)
+    except TypeError:
+        params.pop(define.ROOT_ATTRIBUTE)
+        object.__init__(**params)
 
     return object
 

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -79,7 +79,15 @@ def from_dict(
         # create attribute to signal that object was loaded
         object.__dict__[define.OBJECT_LOADED] = None
 
-    # call __init__()
+    # If function has init decorator, add stream to parameters.
+    # The additional parameter will be popped by the decorator
+    # before the object is created.
+    # If the class does not have a decorator
+    # a TypeError will be raised since we call
+    # the class with an unexpected argument.
+    # Unfortunately, there is no straight-forward way
+    # to check if a method of a class has a decorator
+    # so we have to use a try-except block
     try:
         params[define.ROOT_ATTRIBUTE] = root
         object.__init__(**params)

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -129,8 +129,9 @@ def get_object(
         params: dict,
         root: typing.Optional[str],
         override_args: typing.Dict[str, typing.Any],
-) -> typing.Any:
-    r"""Create object from arguments."""
+) -> (typing.Any, dict):
+    r"""Create object from arguments wihtout calling `__init__()`"""
+
     signature = inspect.signature(cls.__init__)
     supports_kwargs = 'kwargs' in signature.parameters
     supported_params = set([
@@ -199,21 +200,10 @@ def get_object(
         if key in supported_params:
             params[key] = value
 
-    # If function has init decorator, add stream to parameters.
-    # The additional parameter will be popped by the decorator
-    # before the object is created.
-    # If the class does not have a decorator
-    # a TypeError will be raised since we call
-    # the class with an unexpected argument.
-    # Unfortunately, there is no straight-forward way
-    # to check if a method of a class has a decorator
-    # so we have to use a try-except block
-    try:
-        params[define.ROOT_ATTRIBUTE] = root
-        return cls(**params)
-    except TypeError:
-        params.pop(define.ROOT_ATTRIBUTE)
-        return cls(**params)
+    # create object, but do not call __init__() yet
+    object = cls.__new__(cls, **params)
+
+    return object, params
 
 
 def get_version(module_name: str) -> typing.Optional[str]:

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -16,7 +16,7 @@ def test_dictionary():
     assert list(kwargs.keys()) == list(d.keys())
     assert list(kwargs.values()) == list(d.values())
 
-    d_from_yaml_s = d.from_yaml_s(d.to_yaml_s())
+    d_from_yaml_s = audobject.from_yaml_s(d.to_yaml_s())
 
     assert audobject.core.define.OBJECT_LOADED in d_from_yaml_s.__dict__
     assert audobject.core.define.OBJECT_LOADED not in d_from_yaml_s.arguments

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -56,6 +56,24 @@ def test(tmpdir, obj):
     assert obj_from_yaml.is_loaded_from_dict
 
 
+class ObjectTestIsLoadedFromDict(audobject.Object):
+    def __init__(
+            self,
+            loaded: bool,
+    ):
+        assert loaded == self.is_loaded_from_dict
+        self.loaded = loaded
+
+
+def test_is_loaded_from_dict():
+
+    obj = ObjectTestIsLoadedFromDict(False)
+    audobject.from_dict(
+        obj.to_dict(include_version=False),
+        override_args={'loaded': True},
+    )
+
+
 class Point:
     def __init__(
             self,

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -57,21 +57,19 @@ def test(tmpdir, obj):
 
 
 class ObjectTestIsLoadedFromDict(audobject.Object):
-    def __init__(
-            self,
-            loaded: bool,
-    ):
-        assert loaded == self.is_loaded_from_dict
-        self.loaded = loaded
+    def __init__(self):
+        self.loaded = self.is_loaded_from_dict
 
 
 def test_is_loaded_from_dict():
 
-    obj = ObjectTestIsLoadedFromDict(False)
-    audobject.from_dict(
+    obj = ObjectTestIsLoadedFromDict()
+    obj_from_dict = audobject.from_dict(
         obj.to_dict(include_version=False),
-        override_args={'loaded': True},
     )
+
+    assert not obj.loaded
+    assert obj_from_dict.loaded
 
 
 class Point:


### PR DESCRIPTION
Ensures that `Object.is_loaded_from_dict` is already set in `__init__()`.


### Example


```python
class MyObject(audobject.Object):
    def __init__(
            self,
    ):
        print(self.is_loaded_from_dict)

obj = MyObject()
audobject.from_yaml_s(obj.to_yaml_s(include_version=False))
```
```
False
True
```

Before this fix it was printing `False` in both cases.