### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Flake8
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,14 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
+    - name: Install pre-commit hooks
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files
+
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,6 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Install pre-commit hooks
-      run: |
-        pre-commit install --install-hooks
-
-    - name: Code style check via pre-commit
-      run: |
-        pre-commit run --all-files
-
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .idea/
 venv/
 .coverage
+coverage.xml
 docs/pics/*.svg
 docs/.ipynb_checkpoints
 docs/examples/output

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,39 @@ This way, your installation always stays up-to-date,
 even if you pull new changes from the Github repository.
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -2,8 +2,6 @@ import functools
 import inspect
 import typing
 
-import audeer
-
 from audobject.core import define
 from audobject.core import resolver
 

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,8 +1,6 @@
 import importlib
 import inspect
 import operator
-import subprocess
-import sys
 import types
 import typing
 import warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audobject
     --cov-fail-under=100
@@ -45,6 +44,12 @@ addopts =
 xfail_strict = true
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
 parse
+pre-commit
 pytest<7.0.0
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,7 +1,6 @@
 import pytest
 import warnings
 
-import audeer
 import audobject
 
 


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.