### PR TITLE
DOC: correct type of Object.arguments reference

### DIFF
--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -245,7 +245,7 @@ class Object:
     ) -> typing.Dict[str, resolver.DefaultValueType]:
         r"""Converts object to a dictionary.
 
-        Includes items from :meth:`audobject.Object.arguments`.
+        Includes items from :attr:`audobject.Object.arguments`.
         If an argument has a resolver, its value is encoded.
         Usually, the object can be re-instantiated using
         :meth:`audobject.Object.from_dict`.


### PR DESCRIPTION
Fix the referenced type of `audobject.Object.arguments` from method to attributes in all `to_dict()` methods.

![image](https://user-images.githubusercontent.com/173624/222429560-c51799d7-d5b3-4126-a111-37066d47f994.png)
