### PR TITLE
DOC: require sphinx-audeering-theme>=1.2.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 audeer
 jupyter-sphinx
 sphinx
-sphinx-audeering-theme
+sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
The Github pages are published with an old audEERING theme and we need to enforce the new one.
Honestly I have no clue why this happens for the theme package, whereas for other packages Github Actions seems to install automatically the latest package.