### PR TITLE
Remove importlib_metadata backport

### DIFF
--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,4 +1,5 @@
 import importlib
+from importlib.metadata import packages_distributions
 import inspect
 import operator
 import types
@@ -29,7 +30,7 @@ def create_class_key(cls: type, include_version: bool) -> str:
 
     # add package name (if different from module name)
     module_name = cls.__module__.split('.')[0]
-    package_names = importlib.metadata.packages_distributions()
+    package_names = packages_distributions()
     if module_name in package_names:
         package_name = package_names[module_name][0]
         if package_name != module_name:

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -5,8 +5,6 @@ import types
 import typing
 import warnings
 
-from importlib_metadata import packages_distributions
-
 import audeer
 
 from audobject.core import define
@@ -31,7 +29,7 @@ def create_class_key(cls: type, include_version: bool) -> str:
 
     # add package name (if different from module name)
     module_name = cls.__module__.split('.')[0]
-    package_names = packages_distributions()
+    package_names = importlib.metadata.packages_distributions()
     if module_name in package_names:
         package_name = package_names[module_name][0]
         if package_name != module_name:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     oyaml
 setup_requires =
     setuptools_scm
+python_requires >=3.8
 
 [tool:pytest]
 addopts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.18.0
-    importlib-metadata >=4.8.0  # can be replaced with 'importlib.metadata' once we drop support for Python 3.6 / 3.7
     oyaml
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
As we no longer support Python 3.7, we can remove `importlib_metadata` from the requirements and instead use `importlib.metadata` from the standard library.