### PR TITLE
DOC: add ipykernel as dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 audeer
+ipykernel
 jupyter-sphinx
 sphinx
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
`jupter-sphinx` does no longer install this package automatically, so we need to add it to the dependencies.