### PR TITLE
Remove dependency for importlib-metadata

### DIFF
--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,4 +1,5 @@
 import importlib
+from importlib.metadata import packages_distributions
 import inspect
 import operator
 import types

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -6,8 +6,6 @@ import types
 import typing
 import warnings
 
-from importlib_metadata import packages_distributions
-
 import audeer
 from audobject.core import define
 from audobject.core.config import config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ classifiers = [
 ]
 dependencies = [
     'audeer >=1.18.0',
-    # The following can be replaced by "importlib.metadata" with Python 3.10
-    'importlib-metadata >=4.8.0',
     'oyaml',
 ]
 # Get version dynamically from git


### PR DESCRIPTION
Since Python 3.8 it should be sufficient to use the build-in `importlib.metadata` module.