### PR TITLE
TST: add test for failing importlib under macOS

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audb
 parse
 pytest<7.0.0
 pytest-doctestplus

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import yaml
 
+import audb
 import audeer
 import audobject
 import audobject.core.utils as utils
@@ -605,3 +606,8 @@ def test_kwargs_object():
 
     assert o == o2
     assert o2.hide_arg is None
+
+
+def test_audb_flavor():
+    flavor = audb.Flavor(sampling_rate=16000)
+    flavor.path('test', '1.0.0')


### PR DESCRIPTION
This tries to reproduce the error reported in https://github.com/audeering/audobject/issues/84