### PR TITLE
DOC: require sphinx==5.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 audeer
 ipykernel
 jupyter-sphinx
-sphinx
+sphinx ==5.3.0
 sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
Set fixed `sphinx` version to speedup installation of doc packages (otherwise `pip` might start to download all available `sphinx` versions to see which one works with the other requirements).