### PR TITLE
Replace pkg_resources by packaging

### DIFF
--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -2,7 +2,8 @@ import argparse
 import os
 import typing
 
-import pkg_resources
+import packaging.specifiers
+import packaging.version
 
 from audobject.core.decorator import init_decorator
 import audobject.core.define as define
@@ -104,8 +105,8 @@ class Parameter(Object):
         if version is None or self.version is None:
             return True
 
-        v = pkg_resources.parse_version(version)
-        r = pkg_resources.Requirement.parse('param' + self.version)
+        v = packaging.version.parse(version)
+        r = packaging.specifiers.SpecifierSet(self.version)
 
         return v in r
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     # The following can be replaced by "importlib.metadata" with Python 3.10
     'importlib-metadata >=4.8.0',
     'oyaml',
+    'packaging',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import subprocess
 import sys
 
-import pkg_resources
 import pytest
 
 import audobject
@@ -58,8 +57,6 @@ def uninstall(
     for m in list(sys.modules):
         if m.startswith(module):
             sys.modules.pop(m)
-    # force pkg_resources to re-scan site packages
-    pkg_resources._initialize_master_working_set()
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
Closes #98 

* Replaces the deprecated `pkg_resources` used in `audobject.Parameter.__contains__()` by its equivalent implementations in the external [packaging](https://github.com/pypa/packaging) library.
* Removes it uses in `tests/conftest.py` as it is no longer needed 
