### PR TITLE
DOC: discuss limits of resolver.Function

### DIFF
--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -185,9 +185,9 @@ class Function(Base):
     that are not defined or imported
     inside the function.
     For instance,
-    in this example
-    function ``plus_1()`` requires
-    that ``_plus_1()`` is locally defined:
+    the following example will raise an error
+    since ``plus_1()`` relies on ``_plus_1()``,
+    which is defined outside the function:
 
     .. code-block:: python
 

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -181,9 +181,9 @@ class Function(Base):
 
     Note that a decoded function
     might raise a :class:`NameError`,
-    if it relies on other objects,
-    that are locally defined,
-    or imported outside of the function.
+    if it relies on objects or functions
+    that are not defined or imported
+    inside the function.
     For instance,
     in this example
     function ``plus_1()`` requires

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -199,6 +199,9 @@ class Function(Base):
 
         resolver = Function()
         encoded_value = resolver.encode(plus_1)
+        del _plus_1
+        decoded_value = resolver.decode(encoded_value)
+        decoded_value(1)
 
     Examples:
         >>> resolver = Function()

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -181,7 +181,9 @@ class Function(Base):
 
     Note that a decoded function
     might raise a :class:`NameError`,
-    if it relies on other locally defined functions.
+    if it relies on other objects,
+    that are locally defined,
+    or imported outside of the function.
     For instance,
     in this example
     function ``plus_1()`` requires

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -179,6 +179,25 @@ class Function(Base):
     Encodes source code of function and
     dynamically evaluates it when the value is decoded again.
 
+    Note that a decoded function
+    might raise a :class:`NameError`,
+    if it relies on other locally defined functions.
+    For instance,
+    in this example
+    function ``plus_1()`` requires
+    that ``_plus_1()`` is locally defined:
+
+    .. code-block:: python
+
+        def _plus_1(x):
+            return x + 1
+
+        def plus_1(x):
+            return _plus_1(x)  # calls local function -> not serializable
+
+        resolver = Function()
+        encoded_value = resolver.encode(plus_1)
+
     Examples:
         >>> resolver = Function()
         >>> def func(x):


### PR DESCRIPTION
Closes #21

Adds a discussion of the limitation of the `Function()` resolver to its docstring.

![image](https://github.com/audeering/audobject/assets/173624/a885dcc0-c60b-4f0f-929a-b4d91ee44865)
