### PR TITLE
DOC: show version under logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ project = config['project']['name']
 author = ', '.join(author['name'] for author in config['project']['authors'])
 copyright = f'2020-{date.today().year} audEERING GmbH'
 title = 'Documentation'
+version = audeer.git_repo_version()
 
 
 # General -----------------------------------------------------------------


### PR DESCRIPTION
Enables the before missing version number under the logo:

![image](https://github.com/audeering/audobject/assets/173624/ade05827-65ec-4170-af76-15c4ec8f24db)
