### PR TITLE
TST: update to audbackend>=2.0

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -19,7 +19,7 @@ import audobject
         ),
         (  # package and module match
             '''
-            $audbackend.core.filesystem.FileSystem:
+            $audbackend.core.backend.filesystem.FileSystem:
               host: ~/host
               repository: repo
             ''',


### PR DESCRIPTION
Update the tests to handle the new `audbackend` 2.0.0 release.