### PR TITLE
DOC: fix license entry in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Have a look at the installation_ and usage_ instructions.
     :target: https://audeering.github.io/audobject/
     :alt: audobject's documentation
 .. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
-    :target: https://github.com/audeering/audfactory/blob/main/LICENSE
-    :alt: audfactory's MIT license
+    :target: https://github.com/audeering/audobject/blob/main/LICENSE
+    :alt: audobject's MIT license
 .. |python-versions| image:: https://img.shields.io/pypi/pyversions/audobject.svg
     :target: https://pypi.org/project/audobject/
     :alt: audobjects's supported Python versions


### PR DESCRIPTION
The link was pointing to the license of `audfactory` before.