### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020 audEERING GmbH. All rights reserved.
+Copyright (c) 2019-present audEERING GmbH. All rights reserved.
 
 Unauthorized copying of this file, via any medium is strictly prohibited.
 Proprietary and confidential.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@ config = toml.load(audeer.path("..", "pyproject.toml"))
 # Project -----------------------------------------------------------------
 project = config["project"]["name"]
 author = ", ".join(author["name"] for author in config["project"]["authors"])
-copyright = f"2020-{date.today().year} audEERING GmbH"
 title = "Documentation"
 version = audeer.git_repo_version()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-from datetime import date
 import os
 import shutil
 


### PR DESCRIPTION
Change the end of license year to `-present` and remove license year from documentation.