### PR TITLE
TST: use sklearn instead of artifactory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,4 +65,4 @@ def cleanup():
     yield
     # uninstall package temporarily installed by test_install.py
     uninstall("audbackend", "audbackend")
-    uninstall("dohq-artifactory", "artifactory")
+    uninstall("scikit-learn", "sklearn")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,11 +11,11 @@ import audobject
     [
         (  # package and module do not match
             """
-            $dohq-artifactory:artifactory.ArtifactoryPath:
-              token: token
+            $scikit-learn:sklearn.calibration.CalibratedClassifierCV:
+                estimator: None
             """,
-            "dohq-artifactory",
-            "artifactory",
+            "scikit-learn",
+            "sklearn",
         ),
         (  # package and module match
             """


### PR DESCRIPTION
For the test of a package that has a different module and install name, we replace `dohq-artifactory`, `artifactory` by `scikit-learn`, `sklearn`.