### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 import typing
+from typing import Any
 import warnings
 
 import oyaml as yaml
@@ -17,13 +20,13 @@ kwargs_deprecation_warning = (
 
 
 def from_dict(  # noqa: D417
-    d: typing.Dict[str, typing.Any],
-    root: str = None,
+    d: dict[str, Any],
+    root: str | None = None,
     *,
     auto_install: bool = False,
-    override_args: typing.Dict[str, typing.Any] = None,
+    override_args: dict[str, Any] | None = None,
     **kwargs,
-) -> "Object":
+) -> Object:
     r"""Create object from dictionary.
 
     Args:
@@ -181,10 +184,10 @@ def from_yaml_s(  # noqa: D417
 
 
 def _decode_value(
-    value_to_decode: typing.Any,
+    value_to_decode: Any,
     auto_install: bool,
-    override_args: typing.Dict[str, typing.Any],
-) -> typing.Any:
+    override_args: dict[str, Any],
+) -> Any:
     r"""Decode value."""
     if value_to_decode:  # not empty
         if isinstance(value_to_decode, list):

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+import io
 import os
-import typing
 from typing import Any
 import warnings
 
@@ -19,8 +20,8 @@ kwargs_deprecation_warning = (
 )
 
 
-def from_dict(  # noqa: D417
-    d: dict[str, Any],
+def from_dict(
+    d: Mapping[str, Any],
     root: str | None = None,
     *,
     auto_install: bool = False,
@@ -35,6 +36,7 @@ def from_dict(  # noqa: D417
         auto_install: install missing packages needed to create the object
         override_args: override arguments in ``d`` or
             default values of hidden arguments
+        kwargs: arguments to add to override
 
     Returns:
         object
@@ -101,11 +103,11 @@ def from_dict(  # noqa: D417
     return object
 
 
-def from_yaml(  # noqa: D417
-    path_or_stream: typing.Union[str, typing.IO],
+def from_yaml(
+    path_or_stream: str | io.IOBase,
     *,
     auto_install: bool = False,
-    override_args: typing.Dict[str, typing.Any] = None,
+    override_args: dict[str, Any] | None = None,
     **kwargs,
 ) -> "Object":
     r"""Create object from YAML file.
@@ -115,6 +117,7 @@ def from_yaml(  # noqa: D417
         auto_install: install missing packages needed to create the object
         override_args: override arguments in the YAML file or
             default values of hidden arguments
+        kwargs: arguments to add to override
 
     Returns:
         object
@@ -146,11 +149,11 @@ def from_yaml(  # noqa: D417
     )
 
 
-def from_yaml_s(  # noqa: D417
+def from_yaml_s(
     yaml_string: str,
     *,
     auto_install: bool = False,
-    override_args: typing.Dict[str, typing.Any] = None,
+    override_args: dict[str, Any] | None = None,
     **kwargs,
 ) -> "Object":
     r"""Create object from YAML string.
@@ -160,6 +163,7 @@ def from_yaml_s(  # noqa: D417
         auto_install: install missing packages needed to create the object
         override_args: override arguments in the YAML string or
             default values of hidden arguments
+        kwargs: arguments to add to override
 
     Returns:
         object

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 import io
 import os
-from typing import Any
 import warnings
 
 import oyaml as yaml
@@ -21,11 +20,11 @@ kwargs_deprecation_warning = (
 
 
 def from_dict(
-    d: Mapping[str, Any],
+    d: Mapping[str, object],
     root: str | None = None,
     *,
     auto_install: bool = False,
-    override_args: dict[str, Any] | None = None,
+    override_args: dict[str, object] | None = None,
     **kwargs,
 ) -> Object:
     r"""Create object from dictionary.
@@ -107,7 +106,7 @@ def from_yaml(
     path_or_stream: str | io.IOBase,
     *,
     auto_install: bool = False,
-    override_args: dict[str, Any] | None = None,
+    override_args: dict[str, object] | None = None,
     **kwargs,
 ) -> "Object":
     r"""Create object from YAML file.
@@ -153,7 +152,7 @@ def from_yaml_s(
     yaml_string: str,
     *,
     auto_install: bool = False,
-    override_args: dict[str, Any] | None = None,
+    override_args: dict[str, object] | None = None,
     **kwargs,
 ) -> "Object":
     r"""Create object from YAML string.
@@ -188,10 +187,10 @@ def from_yaml_s(
 
 
 def _decode_value(
-    value_to_decode: Any,
+    value_to_decode: object,
     auto_install: bool,
-    override_args: dict[str, Any],
-) -> Any:
+    override_args: dict[str, object],
+) -> object:
     r"""Decode value."""
     if value_to_decode:  # not empty
         if isinstance(value_to_decode, list):

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import functools
 import inspect
-import typing
+from typing import Type
 
 from audobject.core import define
 from audobject.core import resolver
@@ -8,9 +11,9 @@ from audobject.core import resolver
 
 def init_decorator(
     *,
-    borrow: typing.Dict[str, str] = None,
-    hide: typing.Sequence[str] = None,
-    resolvers: typing.Dict[str, typing.Type[resolver.Base]] = None,
+    borrow: dict[str, str] | None = None,
+    hide: Sequence[str] | None = None,
+    resolvers: dict[str, Type[resolver.Base]] | None = None,
 ):
     r"""Decorator for ``__init__`` function of :class:`audobject.Object`.
 

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 import functools
 import inspect
-from typing import Type
 
 from audobject.core import define
 from audobject.core import resolver
@@ -13,7 +12,7 @@ def init_decorator(
     *,
     borrow: dict[str, str] | None = None,
     hide: Sequence[str] | None = None,
-    resolvers: dict[str, Type[resolver.Base]] | None = None,
+    resolvers: dict[str, type[resolver.Base]] | None = None,
 ):
     r"""Decorator for ``__init__`` function of :class:`audobject.Object`.
 

--- a/audobject/core/dictionary.py
+++ b/audobject/core/dictionary.py
@@ -1,4 +1,8 @@
-import typing
+from __future__ import annotations
+
+from collections.abc import ItemsView
+from collections.abc import KeysView
+from collections.abc import ValuesView
 
 from audobject.core import define
 from audobject.core.object import Object
@@ -44,11 +48,11 @@ class Dictionary(Object):
         for key, value in kwargs.items():
             self[key] = value
 
-    def keys(self) -> typing.KeysView[str]:
+    def keys(self) -> KeysView[str]:
         r"""Return the keys."""
         return self._dict_wo_special_attributes.keys()
 
-    def items(self) -> typing.ItemsView[str, typing.Any]:
+    def items(self) -> ItemsView[str, object]:
         r"""Return items view."""
         return self._dict_wo_special_attributes.items()
 
@@ -65,7 +69,7 @@ class Dictionary(Object):
         for key, value in other.items():
             self[key] = value
 
-    def values(self) -> typing.ValuesView[typing.Any]:
+    def values(self) -> ValuesView[object]:
         r"""Return values."""
         return self._dict_wo_special_attributes.values()
 
@@ -85,7 +89,7 @@ class Dictionary(Object):
         r"""Check if key is in dictionary."""
         return key in self._dict_wo_special_attributes
 
-    def __getitem__(self, name: str) -> typing.Any:
+    def __getitem__(self, name: str) -> object:
         r"""Return value at key from dictionary."""
         return self._dict_wo_special_attributes[name]
 
@@ -93,7 +97,7 @@ class Dictionary(Object):
         r"""Number of keys in dictionary."""
         return len(self._dict_wo_special_attributes)
 
-    def __setitem__(self, key: str, value: typing.Any):
+    def __setitem__(self, key: str, value: object):
         r"""Set value at key in dictionary."""
         if key not in self.__dict__[define.KEYWORD_ARGUMENTS]:
             self.__dict__[define.KEYWORD_ARGUMENTS].append(key)

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import collections.abc
+from collections.abc import Mapping
+from collections.abc import Sequence
 import inspect
 import io
 import os
-import typing
+from typing import Any
 import warnings
 
 import oyaml as yaml
@@ -36,7 +37,7 @@ class Object:
         self.__dict__[define.KEYWORD_ARGUMENTS] = list(kwargs)
 
     @property
-    def arguments(self) -> typing.Dict[str, typing.Any]:
+    def arguments(self) -> Mapping[str, Any]:
         r"""Returns arguments that are serialized.
 
         Returns:
@@ -98,7 +99,7 @@ class Object:
             if hasattr(self, value):
                 if hasattr(self.__dict__[value], key):
                     can_borrow = True
-                elif isinstance(self.__dict__[value], collections.abc.Mapping):
+                elif isinstance(self.__dict__[value], Mapping):
                     can_borrow = True
             if not can_borrow:
                 raise RuntimeError(
@@ -116,7 +117,7 @@ class Object:
         return args
 
     @property
-    def borrowed_arguments(self) -> typing.Dict[str, str]:
+    def borrowed_arguments(self) -> Mapping[str, str]:
         r"""Returns borrowed arguments.
 
         Returns:
@@ -130,7 +131,7 @@ class Object:
         return borrowed
 
     @property
-    def hidden_arguments(self) -> typing.List[str]:
+    def hidden_arguments(self) -> Sequence[str]:
         r"""Returns hidden arguments.
 
         Returns:
@@ -192,7 +193,7 @@ class Object:
         alternative="audobject.from_dict",
     )
     def from_dict(  # noqa: D102
-        d: typing.Dict[str, typing.Any],
+        d: Mapping[str, Any],
         root: str = None,
         **kwargs,
     ) -> "Object":  # pragma: no cover
@@ -227,7 +228,7 @@ class Object:
         return from_yaml_s(yaml_string, **kwargs)
 
     @property
-    def resolvers(self) -> typing.Dict[str, resolver.Base]:
+    def resolvers(self) -> Mapping[str, resolver.Base]:
         r"""Return resolvers.
 
         Returns:
@@ -274,7 +275,7 @@ class Object:
         include_version: bool = True,
         flatten: bool = False,
         root: str = None,
-    ) -> typing.Dict[str, resolver.DefaultValueType]:
+    ) -> Mapping[str, resolver.DefaultValueType]:
         r"""Converts object to a dictionary.
 
         Includes items from :attr:`audobject.Object.arguments`.
@@ -316,7 +317,7 @@ class Object:
 
     def to_yaml(
         self,
-        path_or_stream: typing.Union[str, typing.IO],
+        path_or_stream: str | io.IOBase,
         *,
         include_version: bool = True,
     ):
@@ -371,9 +372,9 @@ class Object:
     def _encode_variable(
         self,
         name: str,
-        value: typing.Any,
+        value: Any,
         include_version: bool,
-        root: typing.Optional[str],
+        root: str | None,
     ):
         r"""Encode value.
 
@@ -387,7 +388,7 @@ class Object:
 
     @staticmethod
     def _encode_value(
-        value: typing.Any,
+        value: Any,
         include_version: bool,
     ):
         r"""Default value encoder."""
@@ -418,7 +419,7 @@ class Object:
 
     @staticmethod
     def _flatten(
-        d: typing.Dict[str, resolver.DefaultValueType],
+        d: Mapping[str, resolver.DefaultValueType],
     ):
         r"""Flattens a dictionary."""
 
@@ -450,8 +451,8 @@ class Object:
     def _resolve_value(
         self,
         name: str,
-        value: typing.Any,
-        root: typing.Optional[str],
+        value: Any,
+        root: str | None,
     ) -> resolver.DefaultValueType:
         if value is not None and name in self.resolvers:
             # let resolver know if we write to a stream

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 import inspect
 import io
 import os
-from typing import Any
 import warnings
 
 import oyaml as yaml
@@ -37,7 +36,7 @@ class Object:
         self.__dict__[define.KEYWORD_ARGUMENTS] = list(kwargs)
 
     @property
-    def arguments(self) -> Mapping[str, Any]:
+    def arguments(self) -> Mapping[str, object]:
         r"""Returns arguments that are serialized.
 
         Returns:
@@ -193,7 +192,7 @@ class Object:
         alternative="audobject.from_dict",
     )
     def from_dict(  # noqa: D102
-        d: Mapping[str, Any],
+        d: Mapping[str, object],
         root: str = None,
         **kwargs,
     ) -> "Object":  # pragma: no cover
@@ -372,7 +371,7 @@ class Object:
     def _encode_variable(
         self,
         name: str,
-        value: Any,
+        value: object,
         include_version: bool,
         root: str | None,
     ):
@@ -388,7 +387,7 @@ class Object:
 
     @staticmethod
     def _encode_value(
-        value: Any,
+        value: object,
         include_version: bool,
     ):
         r"""Default value encoder."""
@@ -451,7 +450,7 @@ class Object:
     def _resolve_value(
         self,
         name: str,
-        value: Any,
+        value: object,
         root: str | None,
     ) -> resolver.DefaultValueType:
         if value is not None and name in self.resolvers:

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import collections.abc
 import inspect
+import io
 import os
 import typing
 import warnings
@@ -203,7 +206,7 @@ class Object:
         alternative="audobject.from_yaml",
     )
     def from_yaml(  # noqa: D102
-        path_or_stream: typing.Union[str, typing.IO],
+        path_or_stream: str | io.IOBase,
         **kwargs,
     ) -> "Object":  # pragma: no cover
         from audobject.core.api import from_yaml

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 import os
 import typing
+from typing import Any
 
 import packaging.specifiers
 import packaging.version
@@ -73,9 +77,9 @@ class Parameter(Object):
         *,
         value_type: type = str,
         description: str = "",
-        value: typing.Any = None,
-        default_value: typing.Any = None,
-        choices: typing.Sequence[typing.Any] = None,
+        value: Any = None,
+        default_value: Any = None,
+        choices: Sequence[Any] = None,
         version: str = None,
     ):
         self.value_type = value_type
@@ -99,7 +103,7 @@ class Parameter(Object):
         else:
             self.set_value(default_value)
 
-    def __contains__(self, version: typing.Optional[str]) -> bool:
+    def __contains__(self, version: str | None) -> bool:
         r"""Check if parameter is in parameter object."""
         if version is None or self.version is None:
             return True
@@ -109,7 +113,7 @@ class Parameter(Object):
 
         return version in version_range
 
-    def set_value(self, value: typing.Any):
+    def set_value(self, value: Any):
         r"""Sets a new value.
 
         Applies additional checks, e.g. if value is of the expected type.
@@ -125,7 +129,7 @@ class Parameter(Object):
         self._check_value(value)
         self.value = value
 
-    def _check_value(self, value: typing.Any):
+    def _check_value(self, value: Any):
         r"""Check if value matches expected type."""
         if value is not None and not isinstance(value, self.value_type):
             raise TypeError(
@@ -253,8 +257,8 @@ class Parameters(Dictionary):
         self,
         *,
         delimiter: str = os.path.sep,
-        include: typing.Sequence[str] = None,
-        exclude: typing.Sequence[str] = None,
+        include: Sequence[str] | None = None,
+        exclude: Sequence[str] | None = None,
         sort: bool = False,
     ):
         r"""Creates path from parameters.

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 import os
-import typing
 from typing import Any
 
 import packaging.specifiers
@@ -288,13 +287,13 @@ class Parameters(Dictionary):
         r"""Return parameters as dictionary."""
         return {name: param.value for name, param in self.items()}
 
-    def __getattribute__(self, name) -> typing.Any:  # noqa: D105
+    def __getattribute__(self, name) -> Any:  # noqa: D105
         if not name == "__dict__" and name in self.__dict__:
             p = self.__dict__[name]
             return p.value
         return object.__getattribute__(self, name)
 
-    def __setattr__(self, name: str, value: typing.Any):  # noqa: D105
+    def __setattr__(self, name: str, value: Any):  # noqa: D105
         p = self.__dict__[name]
         p.set_value(value)
 

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 import os
-from typing import Any
 
 import packaging.specifiers
 import packaging.version
@@ -76,9 +75,9 @@ class Parameter(Object):
         *,
         value_type: type = str,
         description: str = "",
-        value: Any = None,
-        default_value: Any = None,
-        choices: Sequence[Any] = None,
+        value: object = None,
+        default_value: object = None,
+        choices: Sequence[object] = None,
         version: str = None,
     ):
         self.value_type = value_type
@@ -112,7 +111,7 @@ class Parameter(Object):
 
         return version in version_range
 
-    def set_value(self, value: Any):
+    def set_value(self, value: object):
         r"""Sets a new value.
 
         Applies additional checks, e.g. if value is of the expected type.
@@ -128,7 +127,7 @@ class Parameter(Object):
         self._check_value(value)
         self.value = value
 
-    def _check_value(self, value: Any):
+    def _check_value(self, value: object):
         r"""Check if value matches expected type."""
         if value is not None and not isinstance(value, self.value_type):
             raise TypeError(
@@ -287,13 +286,13 @@ class Parameters(Dictionary):
         r"""Return parameters as dictionary."""
         return {name: param.value for name, param in self.items()}
 
-    def __getattribute__(self, name) -> Any:  # noqa: D105
+    def __getattribute__(self, name) -> object:  # noqa: D105
         if not name == "__dict__" and name in self.__dict__:
             p = self.__dict__[name]
             return p.value
         return object.__getattribute__(self, name)
 
-    def __setattr__(self, name: str, value: Any):  # noqa: D105
+    def __setattr__(self, name: str, value: object):  # noqa: D105
         p = self.__dict__[name]
         p.set_value(value)
 

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -1,26 +1,19 @@
+from __future__ import annotations
+
 import ast
+from collections.abc import Callable
 import datetime
 import inspect
 import os
 import textwrap
 import types
-import typing
 import warnings
 
 import audeer
 import audobject.core.define as define
 
 
-DefaultValueType = typing.Union[
-    bool,
-    datetime.datetime,
-    dict,
-    float,
-    int,
-    list,
-    None,
-    str,
-]
+DefaultValueType = bool | datetime.datetime | dict | float | int | list | None | str
 
 
 class Base:
@@ -44,7 +37,7 @@ class Base:
         self.__dict__[define.ROOT_ATTRIBUTE] = None
 
     @property
-    def root(self) -> typing.Optional[str]:
+    def root(self) -> str | None:
         r"""Root folder.
 
         Returns root folder when object is serialized to or from a file,
@@ -56,7 +49,7 @@ class Base:
         """
         return self.__dict__[define.ROOT_ATTRIBUTE]
 
-    def decode(self, value: DefaultValueType) -> typing.Any:
+    def decode(self, value: DefaultValueType) -> object:
         r"""Decode value.
 
         Takes the encoded value and converts it back to its original type.
@@ -70,7 +63,7 @@ class Base:
         """
         raise NotImplementedError  # pragma: no cover
 
-    def encode(self, value: typing.Any) -> DefaultValueType:
+    def encode(self, value: object) -> DefaultValueType:
         r"""Encode value.
 
         The type of the returned value must be one of:
@@ -221,7 +214,7 @@ class Function(Base):
 
     """
 
-    def decode(self, value: str) -> typing.Callable:
+    def decode(self, value: str) -> Callable:
         r"""Decode (lambda) function.
 
         Args:
@@ -249,7 +242,7 @@ class Function(Base):
         # This does not preserve defaults and keyword-only arguments,
         # but fortunately this is not relevant for lambda expressions.
 
-        if value.startswith("lambda"):
+        if value.removeprefix("lambda") != value:
             code = compile(value, "<string>", "exec")
             for var in code.co_consts:
                 if isinstance(var, types.CodeType):
@@ -268,8 +261,8 @@ class Function(Base):
 
     def encode(
         self,
-        value: typing.Callable,
-    ) -> typing.Union[str, object]:
+        value: Callable,
+    ) -> str | object:
         r"""Encode (lambda) function.
 
         Args:
@@ -301,7 +294,7 @@ class Function(Base):
         """
         return str
 
-    def get_source(self, func: typing.Callable) -> str:
+    def get_source(self, func: Callable) -> str:
         r"""Obtain source code of (lambda) function.
 
         Retrieving the source of a lambda function can become tricky,
@@ -329,7 +322,7 @@ class Function(Base):
 
     @staticmethod
     def _get_short_lambda_source(
-        lambda_func: typing.Callable,
+        lambda_func: Callable,
     ):  # pragma: no cover
         """Return the source of a (short) lambda function.
 
@@ -526,13 +519,13 @@ class ValueResolver:  # pragma: no cover  # noqa: D101
         self.__dict__[define.ROOT_ATTRIBUTE] = None
 
     @property
-    def root(self) -> typing.Optional[str]:  # noqa: D102
+    def root(self) -> str | None:  # noqa: D102
         return self.__dict__[define.ROOT_ATTRIBUTE]
 
-    def decode(self, value: DefaultValueType) -> typing.Any:  # noqa: D102
+    def decode(self, value: DefaultValueType) -> object:  # noqa: D102
         raise NotImplementedError
 
-    def encode(self, value: typing.Any) -> DefaultValueType:  # noqa: D102
+    def encode(self, value: object) -> DefaultValueType:  # noqa: D102
         raise NotImplementedError
 
     def encode_type(self) -> type:  # noqa: D102

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -4,7 +4,6 @@ import importlib
 import inspect
 import operator
 import types
-from typing import Any
 import warnings
 
 from importlib_metadata import packages_distributions
@@ -131,8 +130,8 @@ def get_object(
     installed_version: str,
     params: dict,
     root: str | None,
-    override_args: dict[str, Any],
-) -> (Any, dict):
+    override_args: dict[str, object],
+) -> (object, dict):
     r"""Create object from arguments without calling `__init__()`."""
     signature = inspect.signature(cls.__init__)
     supports_kwargs = "kwargs" in signature.parameters
@@ -236,7 +235,7 @@ def get_version(module_name: str) -> str | None:
         return None
 
 
-def is_class(value: Any):
+def is_class(value: object):
     r"""Check if value is a class."""
     if isinstance(value, str):
         if value.startswith(define.OBJECT_TAG):

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import importlib
 import inspect
 import operator
 import types
 import typing
+from typing import Any
 import warnings
 
 from importlib_metadata import packages_distributions
@@ -99,7 +102,7 @@ def get_class(
 def get_module(
     package_name: str,
     module_name: str,
-    version: typing.Optional[str],
+    version: str | None,
     auto_install: bool,
 ) -> types.ModuleType:
     r"""Load module."""
@@ -128,9 +131,9 @@ def get_object(
     version: str,
     installed_version: str,
     params: dict,
-    root: typing.Optional[str],
-    override_args: typing.Dict[str, typing.Any],
-) -> (typing.Any, dict):
+    root: str | None,
+    override_args: dict[str, Any],
+) -> (Any, dict):
     r"""Create object from arguments without calling `__init__()`."""
     signature = inspect.signature(cls.__init__)
     supports_kwargs = "kwargs" in signature.parameters

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -4,7 +4,6 @@ import importlib
 import inspect
 import operator
 import types
-import typing
 from typing import Any
 import warnings
 
@@ -229,7 +228,7 @@ def get_object(
     return object, params
 
 
-def get_version(module_name: str) -> typing.Optional[str]:
+def get_version(module_name: str) -> str | None:
     module = importlib.import_module(module_name.split(".")[0])
     if "__version__" in module.__dict__:
         return module.__version__
@@ -237,7 +236,7 @@ def get_version(module_name: str) -> typing.Optional[str]:
         return None
 
 
-def is_class(value: typing.Any):
+def is_class(value: Any):
     r"""Check if value is a class."""
     if isinstance(value, str):
         if value.startswith(define.OBJECT_TAG):
@@ -248,7 +247,7 @@ def is_class(value: typing.Any):
     return False
 
 
-def split_class_key(key: str) -> [str, str, str, typing.Optional[str]]:
+def split_class_key(key: str) -> tuple[str, str, str, str | None]:
     r"""Split class key into package, module, class and version.
 
     Expects a key in the format output by create_class_key().

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -640,7 +640,7 @@ The following class takes as arguments a function with two parameters.
 
 .. jupyter-execute::
 
-    import typing
+    from collections.abc import Callable
 
 
     class MyObjectWithFunction(audobject.Object):
@@ -652,7 +652,7 @@ The following class takes as arguments a function with two parameters.
         )
         def __init__(
                 self,
-                func: typing.Callable[[int, int], int],
+                func: Callable[[int, int], int],
         ):
             self.func = func
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'audeer >=1.18.0',
     # The following can be replaced by "importlib.metadata" with Python 3.10

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -158,10 +158,10 @@ def test_class_key(cls, package, include_version, expected):
     assert key == expected
     p, m, c, v = utils.split_class_key(key)
     if include_version:
-        assert expected.endswith(f"{m}.{c}=={v}")
+        assert expected.removesuffix(f"{m}.{c}=={v}") != expected
     else:
         assert v is None
-        assert expected.endswith(f"{m}.{c}")
+        assert expected.removesuffix(f"{m}.{c}") != expected
     assert p == package
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 import os
 import shutil
-import typing
 
 import pytest
 
@@ -17,9 +19,9 @@ class ObjectWithArgAndKwarg(audobject.Object):
     )
     def __init__(
         self,
-        arg: typing.Any,
+        arg: object,
         *,
-        kwarg: typing.Any,
+        kwarg: object,
     ):
         self.arg = arg
         self.kwarg = kwarg
@@ -77,7 +79,7 @@ class ObjectWithFunction(audobject.Object):
     )
     def __init__(
         self,
-        func: typing.Callable,
+        func: Callable,
     ):
         self.func = func
 
@@ -189,7 +191,7 @@ class ObjectWithTuple(audobject.Object):
     )
     def __init__(
         self,
-        arg: typing.Tuple = None,
+        arg: tuple | None = None,
     ):
         super().__init__()
         self.arg = arg


### PR DESCRIPTION
Closes #110 

This is what has been done to avoid having to use `typing`:


- Using built-in type instead of typing.Type
- Using | for unions
- Using direct imports from collections.abc
- Using object instead of Any
- Using Mapping and Sequence from collections.abc