### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -234,7 +234,7 @@ class Parameters(Dictionary):
             else:
                 help = param.description
 
-            if param.value_type == bool:
+            if isinstance(param.value_type, bool):
                 parser.add_argument(
                     f"--{name}",
                     action="store_true",

--- a/audobject/resolver/__init__.py
+++ b/audobject/resolver/__init__.py
@@ -72,6 +72,7 @@ To write a custom resolver derive from
             return dict
 
 """
+
 from audobject.core.resolver import Base
 from audobject.core.resolver import FilePath
 from audobject.core.resolver import Function

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -37,7 +37,7 @@ def test(tmpdir, obj):
 
     # comparison to other objects,
     # see https://github.com/audeering/audinterface/issues/68
-    assert not obj == type
+    assert not isinstance(obj, type)
     assert repr(obj) == repr(obj_from_yaml)
     assert str(obj) == str(obj_from_yaml)
     assert obj.to_yaml_s() == obj_from_yaml.to_yaml_s()


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.