### PR TITLE
Fix Function.get_source() for lambda functions

### DIFF
--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -7,6 +7,8 @@ import types
 import typing
 import warnings
 
+import asttokens
+
 import audeer
 import audobject.core.define as define
 
@@ -287,9 +289,7 @@ class Function(Base):
             return value
         else:
             raise ValueError(
-                "Cannot decode object "
-                "if it does not derive from "
-                "'audobject.Object'."
+                "Cannot decode object if it does not derive from 'audobject.Object'."
             )
 
     def encode_type(self) -> type:
@@ -334,10 +334,6 @@ class Function(Base):
         """Return the source of a (short) lambda function.
 
         If it's impossible to obtain, returns None.
-
-        Original code:
-        https://gist.github.com/Xion/617c1496ff45f3673a5692c3b0e3f75a
-
         """
         try:
             source_lines, _ = inspect.getsourcelines(lambda_func)
@@ -349,54 +345,15 @@ class Function(Base):
             return None
 
         source_text = os.linesep.join(source_lines).strip()
-
-        # find the AST node of a lambda definition
-        # so we can locate it in the source code
-        source_ast = ast.parse(source_text)
-        lambda_node = next(
-            (node for node in ast.walk(source_ast) if isinstance(node, ast.Lambda)),
-            None,
-        )
-        if lambda_node is None:  # could be a single line `def fn(x): ...`
+        atok = asttokens.ASTTokens(source_text, parse=True)
+        # Search for the first occurring lambda node in AST tree
+        for node in ast.walk(atok.tree):
+            if isinstance(node, ast.Lambda):
+                lambda_node = node
+                break
+        if lambda_node is None:
             return None
-
-        # HACK: Since we can (and most likely will) get source lines
-        # where lambdas are just a part of bigger expressions, they will have
-        # some trailing junk after their definition.
-        #
-        # Unfortunately, AST nodes only keep their _starting_ offsets
-        # from the original source, so we have to determine the end ourselves.
-        # We do that by gradually shaving extra junk from after the definition.
-        lambda_text = source_text[lambda_node.col_offset :]
-        lambda_body_text = source_text[lambda_node.body.col_offset :]
-        min_length = len("lambda:_")  # shortest possible lambda expression
-        while len(lambda_text) > min_length:
-            try:
-                # What's annoying is that sometimes the junk even parses,
-                # but results in a *different* lambda. You'd probably have to
-                # be deliberately malicious to exploit it but here's one way:
-                #
-                #     bloop = lambda x: False, lambda x: True
-                #     get_short_lamnda_source(bloop[0])
-                #
-                # Ideally, we'd just keep shaving until we get the same code,
-                # but that most likely won't happen because we can't replicate
-                # the exact closure environment.
-                code = compile(lambda_body_text, "<unused filename>", "eval")
-
-                # Thus the next best thing is to assume some divergence due
-                # to e.g. LOAD_GLOBAL in original code being LOAD_FAST in
-                # the one compiled above, or vice versa.
-                # But the resulting code should at least be the same *length*
-                # if otherwise the same operations are performed in it.
-                if len(code.co_code) == len(lambda_func.__code__.co_code):
-                    return lambda_text
-            except SyntaxError:
-                pass
-            lambda_text = lambda_text[:-1]
-            lambda_body_text = lambda_body_text[:-1]
-
-        return None
+        return atok.get_text(lambda_node)
 
 
 class Tuple(Base):

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -347,13 +347,12 @@ class Function(Base):
         source_text = os.linesep.join(source_lines).strip()
         atok = asttokens.ASTTokens(source_text, parse=True)
         # Search for the first occurring lambda node in AST tree
+        lambda_node = None
         for node in ast.walk(atok.tree):
             if isinstance(node, ast.Lambda):
                 lambda_node = node
                 break
-        if lambda_node is None:
-            return None
-        return atok.get_text(lambda_node)
+        return None if lambda_node is None else atok.get_text(lambda_node)
 
 
 class Tuple(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
-    'asttokens',
+    'asttokens >=2.0.0',
     'audeer >=1.18.0',
     # The following can be replaced by "importlib.metadata" with Python 3.10
     'importlib-metadata >=4.8.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
+    'asttokens',
     'audeer >=1.18.0',
     # The following can be replaced by "importlib.metadata" with Python 3.10
     'importlib-metadata >=4.8.0',

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -114,6 +114,7 @@ def test_function(tmpdir):
     )
 
     # lambda with float cast
+    # (https://github.com/audeering/audobject/issues/115)
 
     o_lambda_cast = ObjectWithFunction(lambda x: float(x * x))
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -113,6 +113,19 @@ def test_function(tmpdir):
         include_version=False
     )
 
+    # lambda with float cast
+
+    o_lambda_cast = ObjectWithFunction(lambda x: float(x * x))
+
+    path = os.path.join(tmpdir, "lambda.yaml")
+    o_lambda_cast.to_yaml(path, include_version=False)
+    o_lambda_cast_2 = audobject.from_yaml(path)
+
+    assert o_lambda_cast(10.0) == o_lambda_cast(10.0) == 10.0 * 10.0
+    assert o_lambda_cast.to_yaml_s(include_version=False) == o_lambda_cast_2.to_yaml_s(
+        include_version=False
+    )
+
     # function with single positional argument
 
     def func(a):
@@ -174,9 +187,7 @@ def test_function(tmpdir):
     o_func_object_bad = ObjectWithFunction(o_callable_bad)
     with pytest.raises(
         ValueError,
-        match=(
-            "Cannot decode object " "if it does not derive from " "'audobject.Object'."
-        ),
+        match=("Cannot decode object if it does not derive from 'audobject.Object'."),
     ):
         o_func_object_bad.to_yaml_s(include_version=False)
 


### PR DESCRIPTION
Closes #115 

This replaces the hack in `audobject.resolver.Function._get_short_lambda_source()` with a solution using `asttokens`.

A test is added that replicates the previous issue for Python 3.11, and is fixed using the new implementation.

## Summary by Sourcery

Fix lambda source extraction using asttokens and ensure correct serialization of lambda functions, add supporting dependency and tests.

Bug Fixes:
- Fix Function.get_source() to correctly extract lambda definitions on Python 3.11.

Enhancements:
- Replace manual AST-based hack in _get_short_lambda_source with asttokens-based parsing to accurately retrieve lambda source.

Build:
- Add asttokens to project dependencies.

Tests:
- Add test for lambda with float cast to verify serialization round-trip functionality.

Chores:
- Simplify error message formatting in decode ValueError.