### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audobject/core/api.py
+++ b/audobject/core/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Mapping
 import io
 import os

--- a/audobject/core/decorator.py
+++ b/audobject/core/decorator.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import functools
 import inspect

--- a/audobject/core/dictionary.py
+++ b/audobject/core/dictionary.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import ItemsView
 from collections.abc import KeysView
 from collections.abc import ValuesView

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from collections.abc import Sequence
 import inspect

--- a/audobject/core/object.py
+++ b/audobject/core/object.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Mapping
 from collections.abc import Sequence
 import inspect

--- a/audobject/core/parameter.py
+++ b/audobject/core/parameter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 from collections.abc import Sequence
 import os

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import ast
 from collections.abc import Callable
 import datetime

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import inspect
 import operator

--- a/audobject/core/utils.py
+++ b/audobject/core/utils.py
@@ -1,10 +1,9 @@
 import importlib
+from importlib.metadata import packages_distributions
 import inspect
 import operator
 import types
 import warnings
-
-from importlib_metadata import packages_distributions
 
 import audeer
 from audobject.core import define

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ requires-python = '>=3.10'
 dependencies = [
     'asttokens >=2.0.0',
     'audeer >=1.18.0',
-    # The following can be replaced by "importlib.metadata" with Python 3.10
-    'importlib-metadata >=4.8.0',
     'oyaml',
     'packaging',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'asttokens >=2.0.0',
     'audeer >=1.18.0',

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 import os
 import shutil


### PR DESCRIPTION
Remove support for Python 3.9.

It also removes dependency on `importlib-metadata` as this functionality is no given by `importlib.metadata` since Python 3.10.

## Summary by Sourcery

Drop support for Python 3.9 by updating project metadata and CI configuration

Enhancements:
- Remove Python 3.9 classifiers and bump requires-python to >=3.10 in pyproject.toml

CI:
- Remove Python 3.9 from the GitHub Actions test matrix