### PR TITLE
Include only audobject* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     'parse',
     'pytest',
     'pytest-doctestplus',
-    'pytest-console-scripts',
+    # 'pytest-console-scripts',
     'pytest-cov',
     'sphinx ==5.3.0',
     'sphinx-audeering-theme >=1.2.1',
@@ -213,6 +213,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+include = ['audobject*']
 
 # ----- setuptools_scm ----------------------------------------------------
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     'parse',
     'pytest',
     'pytest-doctestplus',
-    # 'pytest-console-scripts',
+    'pytest-console-scripts',
     'pytest-cov',
     'sphinx ==5.3.0',
     'sphinx-audeering-theme >=1.2.1',


### PR DESCRIPTION
This restricts the files included in the Python package to `audobject*`.

Same fix as audeering/audb#560 (audeering/audb#559): the empty `[tool.setuptools.packages.find]` defaults to `namespaces = true`, causing setuptools to also pick up `tests/`, `docs/`, `benchmarks/`, and `build/` as top-level namespace packages. They end up installed under `site-packages/` and shadow any local `tests/` or `docs/` packages in downstream projects.