### PR TITLE
Fix tests to not check for warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     'ipykernel',
     'jupyter-sphinx',
     'parse',
-    'pytest<7.0.0',
+    'pytest',
     'pytest-doctestplus',
     'pytest-console-scripts',
     'pytest-cov',

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -476,8 +476,7 @@ def test_bad_object():
             self.bar = foo
 
     with pytest.raises(RuntimeError):
-        with pytest.warns(RuntimeWarning):
-            BadObject("foo")  # cannot hide argument without default value
+        BadObject("foo")  # cannot hide argument without default value
 
     class BadObject(audobject.Object):
         @audobject.init_decorator(

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -475,8 +475,9 @@ def test_bad_object():
         ):
             self.bar = foo
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         BadObject("foo")  # cannot hide argument without default value
+    assert "Cannot hide arguments ['foo']" in str(excinfo.value)
 
     class BadObject(audobject.Object):
         @audobject.init_decorator(


### PR DESCRIPTION
Do not check for warning in a test when it should raise an error as newer versions of `pytest` will not match this. 