### PR TITLE
Use sybil for doctests

### DIFF
--- a/audobject/core/conftest.py
+++ b/audobject/core/conftest.py
@@ -1,0 +1,65 @@
+import doctest
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+import linecache
+
+import pytest
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
+
+
+# --- Make ``inspect.getsource`` work for doctest-defined functions -------
+#
+# See ``docs/conftest.py`` for an in-depth explanation.  In short, ``doctest``
+# compiles every example with a synthetic filename but does not register the
+# source with ``linecache``, so ``inspect.getsource`` (used by
+# ``audobject.resolver.Function``) raises ``OSError`` for functions defined
+# inline in doctests.  We wrap ``DocTestRunner.run`` to register the source.
+_orig_doctest_run = doctest.DocTestRunner.run
+
+
+def _run_with_linecache(self, test, *args, **kwargs):
+    counter = getattr(self, "_example_counter", 0) + 1
+    self._example_counter = counter
+    test.name = f"{test.name}-{counter}"
+    for examplenum, example in enumerate(test.examples):
+        filename = "<doctest %s[%d]>" % (test.name, examplenum)
+        lines = example.source.splitlines(keepends=True)
+        linecache.cache[filename] = (len(example.source), None, lines, filename)
+    return _orig_doctest_run(self, test, *args, **kwargs)
+
+
+@pytest.fixture(scope="session")
+def _patch_doctest_runner():
+    """Install the linecache-aware ``DocTestRunner.run`` for doctests."""
+    doctest.DocTestRunner.run = _run_with_linecache
+    try:
+        yield
+    finally:
+        doctest.DocTestRunner.run = _orig_doctest_run
+
+
+# Collect doctests from docstrings in Python source files.
+#
+# Sybil's default document type for ``*.py`` files is
+# ``PythonDocStringDocument``, which:
+#
+# * extracts only the text of docstrings (so ordinary Python code is ignored),
+# * imports the source file as a Python module and populates the doctest
+#   namespace with the module's globals.
+#
+# The latter means classes defined in doctests get the correct ``__module__``
+# attribute (e.g. ``audobject.core.object``), matching the expected output
+# shown in the docstrings.
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
+        PythonCodeBlockParser(),
+        SkipParser(),
+    ],
+    patterns=["*.py"],
+    excludes=["conftest.py"],
+    fixtures=["_patch_doctest_runner"],
+).pytest()

--- a/audobject/core/resolver.py
+++ b/audobject/core/resolver.py
@@ -193,6 +193,8 @@ class Function(Base):
     since ``plus_1()`` relies on ``_plus_1()``,
     which is defined outside the function:
 
+    .. skip: next
+
     .. code-block:: python
 
         def _plus_1(x):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ exclude_patterns = [
 templates_path = ["_templates"]
 pygments_style = None
 extensions = [
-    "jupyter_sphinx",  # executing code blocks
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",  # support for Google-style docstrings
     "sphinx.ext.autosummary",

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,5 +1,7 @@
+import doctest
 from doctest import ELLIPSIS
 from doctest import NORMALIZE_WHITESPACE
+import linecache
 import os
 import sys
 import types
@@ -12,6 +14,44 @@ from sybil.parsers.rest import SkipParser
 
 import audobject
 import audobject.core.utils
+
+
+# --- Make ``inspect.getsource`` work for doctest-defined functions -------
+#
+# ``audobject.resolver.Function`` calls ``inspect.getsource(func)`` to
+# serialise the source code of a function. ``inspect.getsource`` reads
+# source lines from ``linecache`` keyed by ``func.__code__.co_filename``.
+#
+# Python's ``doctest`` module compiles each example with a synthetic
+# filename (``<doctest name[N]>``) but does *not* register the source
+# in ``linecache``, so ``inspect.getsource`` raises ``OSError`` for
+# functions defined inline in doctests. IPython/Jupyter avoids this by
+# registering cell sources in ``linecache`` — we do the same here by
+# wrapping ``DocTestRunner.run``.
+#
+# sybil feeds every example through ``DocTestRunner.run`` as its own
+# single-example ``DocTest``, and ``doctest`` builds the filename as
+# ``<doctest <test.name>[<examplenum>]>``. If we left ``test.name``
+# alone, every example from the same rst file would end up with the
+# same filename (``[examplenum]`` is always 0) and each linecache
+# entry would overwrite the previous one. We therefore make the name
+# unique per example using a monotonic counter.
+_orig_doctest_run = doctest.DocTestRunner.run
+_example_counter = 0
+
+
+def _run_with_linecache(self, test, *args, **kwargs):
+    global _example_counter
+    _example_counter += 1
+    test.name = f"{test.name}-{_example_counter}"
+    for examplenum, example in enumerate(test.examples):
+        filename = "<doctest %s[%d]>" % (test.name, examplenum)
+        lines = example.source.splitlines(keepends=True)
+        linecache.cache[filename] = (len(example.source), None, lines, filename)
+    return _orig_doctest_run(self, test, *args, **kwargs)
+
+
+doctest.DocTestRunner.run = _run_with_linecache
 
 
 # --- Fake user package ---------------------------------------------------

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -50,7 +50,19 @@ def _run_with_linecache(self, test, *args, **kwargs):
     return _orig_doctest_run(self, test, *args, **kwargs)
 
 
-doctest.DocTestRunner.run = _run_with_linecache
+@pytest.fixture(scope="session")
+def _patch_doctest_runner():
+    """Install the linecache-aware ``DocTestRunner.run`` for doctests.
+
+    Scoped to the session so the original is restored after the docs
+    tests run, keeping the patch from leaking into other tests in the
+    same process.
+    """
+    doctest.DocTestRunner.run = _run_with_linecache
+    try:
+        yield
+    finally:
+        doctest.DocTestRunner.run = _orig_doctest_run
 
 
 # --- Fake user package ---------------------------------------------------
@@ -96,7 +108,6 @@ class _MyPkgModule(types.ModuleType):
 
 
 _mypkg = _MyPkgModule("mypkg")
-sys.modules["mypkg"] = _mypkg
 
 _orig_get_version = audobject.core.utils.get_version
 
@@ -108,10 +119,27 @@ def _patched_get_version(module_name):
     return _orig_get_version(module_name)
 
 
-# ``get_version`` inspects ``module.__dict__`` directly, bypassing our
-# module ``__getattr__``, so we patch it to read from the live doctest
-# namespace whenever ``mypkg`` is queried.
-audobject.core.utils.get_version = _patched_get_version
+@pytest.fixture(scope="session")
+def _patch_mypkg_version():
+    """Register the fake ``mypkg`` module and patch ``get_version``.
+
+    ``get_version`` inspects ``module.__dict__`` directly, bypassing our
+    module's ``__getattr__``, so we patch it to read from the live
+    doctest namespace whenever ``mypkg`` is queried. Both changes are
+    scoped to the session and reverted on teardown so other tests in
+    the same process are unaffected.
+    """
+    orig_module = sys.modules.get("mypkg")
+    sys.modules["mypkg"] = _mypkg
+    audobject.core.utils.get_version = _patched_get_version
+    try:
+        yield
+    finally:
+        audobject.core.utils.get_version = _orig_get_version
+        if orig_module is None:
+            sys.modules.pop("mypkg", None)
+        else:
+            sys.modules["mypkg"] = orig_module
 
 
 def imports(namespace):
@@ -146,6 +174,6 @@ pytest_collect_file = Sybil(
         SkipParser(),
     ],
     patterns=["usage.rst"],
-    fixtures=["run_in_tmpdir"],
+    fixtures=["run_in_tmpdir", "_patch_doctest_runner", "_patch_mypkg_version"],
     setup=imports,
 ).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -35,15 +35,14 @@ import audobject.core.utils
 # alone, every example from the same rst file would end up with the
 # same filename (``[examplenum]`` is always 0) and each linecache
 # entry would overwrite the previous one. We therefore make the name
-# unique per example using a monotonic counter.
+# unique per example using a counter stored on the runner instance.
 _orig_doctest_run = doctest.DocTestRunner.run
-_example_counter = 0
 
 
 def _run_with_linecache(self, test, *args, **kwargs):
-    global _example_counter
-    _example_counter += 1
-    test.name = f"{test.name}-{_example_counter}"
+    counter = getattr(self, "_example_counter", 0) + 1
+    self._example_counter = counter
+    test.name = f"{test.name}-{counter}"
     for examplenum, example in enumerate(test.examples):
         filename = "<doctest %s[%d]>" % (test.name, examplenum)
         lines = example.source.splitlines(keepends=True)
@@ -74,10 +73,7 @@ doctest.DocTestRunner.run = _run_with_linecache
 #      defined there get ``__module__ == "mypkg"``;
 #   2) patch ``audobject.core.utils.get_version`` so that when asked for
 #      ``mypkg``'s version it returns the current ``__version__`` from
-#      the live doctest namespace.
-_doctest_namespace: dict = {}
-
-
+#      the live doctest namespace bound on the fake module.
 class _MyPkgModule(types.ModuleType):
     """Fake ``mypkg`` module backed by the live doctest namespace.
 
@@ -86,9 +82,16 @@ class _MyPkgModule(types.ModuleType):
     deserialising YAML.
     """
 
+    def __init__(self, name):
+        super().__init__(name)
+        self._namespace: dict = {}
+
+    def bind_namespace(self, namespace: dict) -> None:
+        self._namespace = namespace
+
     def __getattr__(self, name):
-        if name in _doctest_namespace:
-            return _doctest_namespace[name]
+        if name in self._namespace:
+            return self._namespace[name]
         raise AttributeError(name)
 
 
@@ -100,8 +103,8 @@ _orig_get_version = audobject.core.utils.get_version
 
 def _patched_get_version(module_name):
     root = module_name.split(".")[0]
-    if root == "mypkg" and "__version__" in _doctest_namespace:
-        return _doctest_namespace["__version__"]
+    if root == "mypkg" and "__version__" in _mypkg._namespace:
+        return _mypkg._namespace["__version__"]
     return _orig_get_version(module_name)
 
 
@@ -113,7 +116,6 @@ audobject.core.utils.get_version = _patched_get_version
 
 def imports(namespace):
     """Provide modules to the doctest namespace."""
-    global _doctest_namespace
     # Make classes defined here end up in the fake ``mypkg`` module.
     namespace["__name__"] = "mypkg"
     namespace["__version__"] = "1.0.0"
@@ -121,7 +123,7 @@ def imports(namespace):
     # Bind the live namespace so ``_patched_get_version`` and the fake
     # ``mypkg`` module can look up ``__version__`` and classes as they
     # are defined during doctest execution.
-    _doctest_namespace = namespace
+    _mypkg.bind_namespace(namespace)
 
 
 @pytest.fixture(scope="module")

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,109 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+import os
+import sys
+import types
+
+import pytest
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
+
+import audobject
+import audobject.core.utils
+
+
+# --- Fake user package ---------------------------------------------------
+#
+# audobject stores the class module path and its ``__version__`` in the
+# serialised YAML representation of every object.  In the original docs,
+# examples were executed in a Jupyter kernel where the classes ended up
+# in the ``__main__`` module, and ``__version__ = "X"`` set
+# ``__main__.__version__`` which ``audobject.core.utils.get_version``
+# could pick up.
+#
+# Sybil executes doctests via ``exec`` in a plain namespace, so classes
+# defined there would otherwise have ``__module__ == "builtins"`` and
+# ``__version__`` assignments would not propagate to the module object
+# that ``get_version`` inspects.
+#
+# To preserve the original docs style (``__version__ = "1.0.0"``), we:
+#   1) register a fake ``mypkg`` module in ``sys.modules`` and make the
+#      doctest namespace pretend ``__name__ == "mypkg"`` so classes
+#      defined there get ``__module__ == "mypkg"``;
+#   2) patch ``audobject.core.utils.get_version`` so that when asked for
+#      ``mypkg``'s version it returns the current ``__version__`` from
+#      the live doctest namespace.
+_doctest_namespace: dict = {}
+
+
+class _MyPkgModule(types.ModuleType):
+    """Fake ``mypkg`` module backed by the live doctest namespace.
+
+    Classes defined in the doctest namespace are looked up here via
+    ``__getattr__`` so that ``audobject`` can re-instantiate them when
+    deserialising YAML.
+    """
+
+    def __getattr__(self, name):
+        if name in _doctest_namespace:
+            return _doctest_namespace[name]
+        raise AttributeError(name)
+
+
+_mypkg = _MyPkgModule("mypkg")
+sys.modules["mypkg"] = _mypkg
+
+_orig_get_version = audobject.core.utils.get_version
+
+
+def _patched_get_version(module_name):
+    root = module_name.split(".")[0]
+    if root == "mypkg" and "__version__" in _doctest_namespace:
+        return _doctest_namespace["__version__"]
+    return _orig_get_version(module_name)
+
+
+# ``get_version`` inspects ``module.__dict__`` directly, bypassing our
+# module ``__getattr__``, so we patch it to read from the live doctest
+# namespace whenever ``mypkg`` is queried.
+audobject.core.utils.get_version = _patched_get_version
+
+
+def imports(namespace):
+    """Provide modules to the doctest namespace."""
+    global _doctest_namespace
+    # Make classes defined here end up in the fake ``mypkg`` module.
+    namespace["__name__"] = "mypkg"
+    namespace["__version__"] = "1.0.0"
+    namespace["audobject"] = audobject
+    # Bind the live namespace so ``_patched_get_version`` and the fake
+    # ``mypkg`` module can look up ``__version__`` and classes as they
+    # are defined during doctest execution.
+    _doctest_namespace = namespace
+
+
+@pytest.fixture(scope="module")
+def run_in_tmpdir(tmpdir_factory):
+    """Move to a persistent tmpdir for execution of a whole file."""
+    tmpdir = tmpdir_factory.mktemp("tmp")
+    current_dir = os.getcwd()
+    os.chdir(tmpdir)
+
+    yield
+
+    os.chdir(current_dir)
+
+
+# Collect doctests
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
+        PythonCodeBlockParser(),
+        SkipParser(),
+    ],
+    patterns=["usage.rst"],
+    fixtures=["run_in_tmpdir"],
+    setup=imports,
+).pytest()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,26 +6,13 @@ a base class, namely :class:`audobject.Object`,
 which allows it to convert an object to a YAML string
 and re-instantiate the object from it.
 
-.. set temporal working directory
-.. jupyter-execute::
-    :hide-code:
-
-    import os
-    import audeer
-    _cwd_root = os.getcwd()
-    _tmp_root = audeer.mkdir(os.path.join("docs", "tmp"))
-    os.chdir(_tmp_root)
-
 
 Object class
 ------------
 
 Let's create a class that derives from :class:`audobject.Object`.
 
-.. jupyter-execute::
-
-    import audobject
-
+.. code-block:: python
 
     __version__ = "1.0.0"  # pretend we have a package version
 
@@ -45,10 +32,9 @@ Let's create a class that derives from :class:`audobject.Object`.
 
 Now we instantiate an object and print it.
 
-.. jupyter-execute::
-
-    o = MyObject("hello object!", num_repeat=2)
-    print(o)
+>>> o = MyObject("hello object!", num_repeat=2)
+>>> print(o)
+hello object! hello object!
 
 As expected we see that ``string`` is repeated ``num_repeat`` times.
 But since we derived from :class:`audobject.Object`
@@ -57,91 +43,83 @@ we get some additional functionality.
 For instance, we can get a dictionary
 with the arguments the object was initialized with.
 
-.. jupyter-execute::
-
-    o.arguments
+>>> o.arguments
+{'string': 'hello object!', 'num_repeat': 2}
 
 Or a dictionary that also stores module,
 object name and package version.
 
-.. jupyter-execute::
-
-    o_dict = o.to_dict()
-    print(o_dict)
+>>> o_dict = o.to_dict()
+>>> print(o_dict)
+{'$mypkg.MyObject==1.0.0': {'string': 'hello object!', 'num_repeat': 2}}
 
 And we can re-instantiate the object from it.
 
-.. jupyter-execute::
-
-    o2 = audobject.from_dict(o_dict)
-    print(o2)
+>>> o2 = audobject.from_dict(o_dict)
+>>> print(o2)
+hello object! hello object!
 
 We can also convert it to YAML.
 
-.. jupyter-execute::
-
-    o_yaml = o.to_yaml_s()
-    print(o_yaml)
+>>> o_yaml = o.to_yaml_s()
+>>> print(o_yaml)
+$mypkg.MyObject==1.0.0:
+  string: hello object!
+  num_repeat: 2
+<BLANKLINE>
 
 And create the object from YAML.
 
-.. jupyter-execute::
-
-    o3 = audobject.from_yaml_s(o_yaml)
-    print(o3)
+>>> o3 = audobject.from_yaml_s(o_yaml)
+>>> print(o3)
+hello object! hello object!
 
 If we want, we can override
 arguments when we instantiate an object.
 
-.. jupyter-execute::
-
-    o4 = audobject.from_yaml_s(
-        o_yaml,
-        override_args={
-            "string": "I was set to a different value!"
-        }
-    )
-    print(o4)
+>>> o4 = audobject.from_yaml_s(
+...     o_yaml,
+...     override_args={
+...         "string": "I was set to a different value!"
+...     }
+... )
+>>> print(o4)
+I was set to a different value! I was set to a different value!
 
 Or save an object to disk and re-instantiate it from there.
 
-.. jupyter-execute::
-
-    file = "my.yaml"
-    o.to_yaml(file)
-    o5 = audobject.from_yaml(file)
-    print(o5)
+>>> file = "my.yaml"
+>>> o.to_yaml(file)
+>>> o5 = audobject.from_yaml(file)
+>>> print(o5)
+hello object! hello object!
 
 Object ID
 ---------
 
 Every object has an ID.
 
-.. jupyter-execute::
-
-    o = MyObject("I am unique!", num_repeat=2)
-    print(o.id)
+>>> o = MyObject("I am unique!", num_repeat=2)
+>>> print(o.id)
+9268115e-7caf-aa02-7fbb-da4e83b2f575
 
 Objects with exact same arguments share the same ID.
 
-.. jupyter-execute::
-
-    o2 = MyObject("I am unique!", num_repeat=2)
-    print(o.id == o2.id)
+>>> o2 = MyObject("I am unique!", num_repeat=2)
+>>> print(o.id == o2.id)
+True
 
 When an object is serialized the ID does not change.
 
-.. jupyter-execute::
-
-    o3 = audobject.from_yaml_s(o.to_yaml_s())
-    print(o3.id == o.id)
+>>> o3 = audobject.from_yaml_s(o.to_yaml_s())
+>>> print(o3.id == o.id)
+True
 
 Objects with different arguments get different IDs.
 
-.. jupyter-execute::
-
-    o4 = MyObject("I am different!", num_repeat=2)
-    print(o.id == o4.id)
+>>> o4 = MyObject("I am different!", num_repeat=2)
+>>> print(o.id == o4.id)
+False
 
 Malformed objects
 -----------------
@@ -151,7 +129,7 @@ every argument to an attribute with the same name.
 This ensures that we can re-instantiate the object from YAML.
 Let's create a class where we don't follow this rule.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyBadObject(audobject.Object):
 
@@ -169,21 +147,17 @@ Let's create a class where we don't follow this rule.
 
 At a first glance, everything works as expected.
 
-.. jupyter-execute::
+>>> bad = MyBadObject("test", num_repeat=2)
+>>> print(bad)
+test test
 
-    bad = MyBadObject("test", num_repeat=2)
-    print(bad)
+But if we try to serialize the object to YAML,
+we'll get an error.
 
-But if we try to instantiate the object
-from YAML, we'll get an error.
-
-.. jupyter-execute::
-    :stderr:
-    :raises:
-
-    bad_yaml = bad.to_yaml_s()
-    bad2 = audobject.from_yaml_s(bad_yaml)
-    print(bad2)
+>>> bad.to_yaml_s()
+Traceback (most recent call last):
+    ...
+RuntimeError: Arguments ['string', 'num_repeat'] of <class 'mypkg.MyBadObject'> not assigned to attributes of same name.
 
 However, in the next section we'll learn
 that it's possible to hide arguments.
@@ -200,7 +174,7 @@ Hidden arguments are arguments that are not serialized.
 Let's introduce a new argument ``verbose`` and hide it
 with the :meth:`audobject.init_decorator` decorator.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyObjectWithHiddenArgument(audobject.Object):
 
@@ -225,57 +199,57 @@ with the :meth:`audobject.init_decorator` decorator.
 
 If we set ``verbose=True``, debug message are printed.
 
-.. jupyter-execute::
-
-    o = MyObjectWithHiddenArgument(
-        "hello object!",
-        num_repeat=3,
-        verbose=True,
-    )
-    print(o)
+>>> o = MyObjectWithHiddenArgument(
+...     "hello object!",
+...     num_repeat=3,
+...     verbose=True,
+... )
+>>> print(o)
+LOG: print message
+hello object! hello object! hello object!
 
 But since ``verbose`` is a hidden argument,
 it is not stored to YAML.
 
-.. jupyter-execute::
-
-    o_yaml = o.to_yaml_s()
-    print(o_yaml)
+>>> o_yaml = o.to_yaml_s()
+>>> print(o_yaml)
+$mypkg.MyObjectWithHiddenArgument==1.0.0:
+  string: hello object!
+  num_repeat: 3
+<BLANKLINE>
 
 That means when we re-instantiate the object,
 ``verbose`` will be set to its default value (``False``)
 and we won't see debug messages.
 
-.. jupyter-execute::
-
-    o2 = audobject.from_yaml_s(o_yaml)
-    print(o2)
+>>> o2 = audobject.from_yaml_s(o_yaml)
+>>> print(o2)
+hello object! hello object! hello object!
 
 However, we can still set ``verbose``
 to ``True`` when we load the object.
 
-.. jupyter-execute::
-
-    o3 = audobject.from_yaml_s(
-        o_yaml,
-        override_args={
-            "verbose": True,
-        }
-    )
-    print(o3)
+>>> o3 = audobject.from_yaml_s(
+...     o_yaml,
+...     override_args={
+...         "verbose": True,
+...     }
+... )
+>>> print(o3)
+LOG: print message
+hello object! hello object! hello object!
 
 Note that hidden arguments are not taken into account for the UID.
 
-.. jupyter-execute::
-
-    print(o2.id)
-    print(o3.id)
+>>> print(o2.id)
+26eddeb8-2ead-69e1-0eb2-37c2a2d19174
+>>> print(o3.id)
+26eddeb8-2ead-69e1-0eb2-37c2a2d19174
 
 It is possible to get a list of hidden arguments.
 
-.. jupyter-execute::
-
-    o3.hidden_arguments
+>>> o3.hidden_arguments
+['verbose']
 
 Borrowed arguments
 ------------------
@@ -286,7 +260,7 @@ from ``self.point`` and a dictionary ``self.d``.
 Using borrowed arguments it becomes possible
 to add properties with the name of an argument.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class Point:
 
@@ -321,8 +295,13 @@ to add properties with the name of an argument.
         def z(self):  # property sharing the name of an argument
             return self.d["z"]
 
-    o = ObjectWithBorrowedArguments(0, 1, 2)
-    print(o.to_yaml_s())
+>>> o = ObjectWithBorrowedArguments(0, 1, 2)
+>>> print(o.to_yaml_s())
+$mypkg.ObjectWithBorrowedArguments==1.0.0:
+  x: 0
+  y: 1
+  z: 2
+<BLANKLINE>
 
 Object with kwargs
 ------------------
@@ -334,7 +313,7 @@ since we cannot figure out
 the names of additional keyword arguments
 from the signature of the function.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyObjectWithKwargs(audobject.Object):
 
@@ -351,17 +330,20 @@ from the signature of the function.
         def __str__(self) -> str:
             return " ".join([self.string] * self.num_repeat)
 
-    o = MyObjectWithKwargs("I have kwargs", num_repeat=3)
-    print(o)
+>>> o = MyObjectWithKwargs("I have kwargs", num_repeat=3)
+>>> print(o)
+I have kwargs I have kwargs I have kwargs
 
 When we serialize the object,
 we see that keyword argument
 ``num_repeat`` will be included.
 
-.. jupyter-execute::
-
-    o_yaml = o.to_yaml_s()
-    print(o_yaml)
+>>> o_yaml = o.to_yaml_s()
+>>> print(o_yaml)
+$mypkg.MyObjectWithKwargs==1.0.0:
+  string: I have kwargs
+  num_repeat: 3
+<BLANKLINE>
 
 Object as argument
 ------------------
@@ -370,7 +352,7 @@ It is possible to have arguments of
 type :class:`audobject.Object`.
 For instance, we can define the following class.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MySuperObject(audobject.Object):
 
@@ -385,25 +367,27 @@ For instance, we can define the following class.
 
 And initialize it with an instance of ``MyObject``.
 
-.. jupyter-execute::
-
-    o = MyObject("eat me!")
-    w = MySuperObject(o)
-    print(w)
+>>> o = MyObject("eat me!")
+>>> w = MySuperObject(o)
+>>> print(w)
+[eat me!]
 
 This translates to the following YAML string.
 
-.. jupyter-execute::
-
-    w_yaml = w.to_yaml_s()
-    print(w_yaml)
+>>> w_yaml = w.to_yaml_s()
+>>> print(w_yaml)
+$mypkg.MySuperObject==1.0.0:
+  obj:
+    $mypkg.MyObject==1.0.0:
+      string: eat me!
+      num_repeat: 1
+<BLANKLINE>
 
 From which we can re-instantiate the object.
 
-.. jupyter-execute::
-
-    w2 = audobject.from_yaml_s(w_yaml)
-    print(w2)
+>>> w2 = audobject.from_yaml_s(w_yaml)
+>>> print(w2)
+[eat me!]
 
 Value resolver
 --------------
@@ -427,7 +411,7 @@ and clutter the YAML syntax.
 
 To illustrate this, let's use an instance of timedelta_.
 
-.. jupyter-execute::
+.. code-block:: python
 
     from datetime import timedelta
 
@@ -445,25 +429,25 @@ To illustrate this, let's use an instance of timedelta_.
 
 As before, we can create an instance and print it.
 
-.. jupyter-execute::
-
-    delta = timedelta(
-        days=50,
-        seconds=27,
-        microseconds=10,
-        milliseconds=29000,
-        minutes=5,
-        hours=8,
-        weeks=2
-    )
-    d = MyDeltaObject(delta)
-    print(d)
+>>> delta = timedelta(
+...     days=50,
+...     seconds=27,
+...     microseconds=10,
+...     milliseconds=29000,
+...     minutes=5,
+...     hours=8,
+...     weeks=2
+... )
+>>> d = MyDeltaObject(delta)
+>>> print(d)
+64 days, 8:05:56.000010
 
 But if we convert it to YAML,
 we'll see a warning.
 
-.. jupyter-execute::
-    :stderr:
+.. skip: next
+
+.. code-block:: python
 
     d_yaml = d.to_yaml_s()
     print(d_yaml)
@@ -481,7 +465,7 @@ We can avoid this by providing a custom resolver
 that defines how a timedelta_ object should be
 encoded and decoded.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class DeltaResolver(audobject.resolver.Base):
 
@@ -507,7 +491,7 @@ To apply our custom resolver to the
 :meth:`audobject.init_decorator`
 decorator of the ``__init__`` function.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyResolvedDeltaObject(audobject.Object):
 
@@ -526,11 +510,15 @@ decorator of the ``__init__`` function.
 Now, we don't get a warning
 and the ``!!python/object`` tag has disappeared.
 
-.. jupyter-execute::
-
-    d = MyResolvedDeltaObject(delta)
-    d_yaml = d.to_yaml_s()
-    print(d_yaml)
+>>> d = MyResolvedDeltaObject(delta)
+>>> d_yaml = d.to_yaml_s()
+>>> print(d_yaml)
+$mypkg.MyResolvedDeltaObject==1.0.0:
+  delta:
+    days: 64
+    seconds: 29156
+    microseconds: 10
+<BLANKLINE>
 
 Resolve file paths
 ------------------
@@ -548,7 +536,7 @@ we want to make sure that:
 This can be achieved using
 :class:`audobject.resolver.FilePath`.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyObjectWithFile(audobject.Object):
 
@@ -570,60 +558,55 @@ This can be achieved using
 
 Here, we create a file and pass it to the object.
 
-.. jupyter-execute::
-
-    import os
-    import audeer
-
-    root = "root"
-
-    res_path = os.path.join(root, "re", "source.txt")  # root/re/source.txt
-    audeer.mkdir(os.path.dirname(res_path))
-    with open(res_path, "w") as fp:
-        fp.write("You found me!")
-
-    o = MyObjectWithFile(res_path)
-    o.read()
+>>> import os
+>>> import audeer
+>>> root = "root"
+>>> res_path = os.path.join(root, "re", "source.txt")  # root/re/source.txt
+>>> _ = audeer.mkdir(os.path.dirname(res_path))
+>>> with open(res_path, "w") as fp:
+...     _ = fp.write("You found me!")
+>>> o = MyObjectWithFile(res_path)
+>>> o.read()
+root/re/source.txt
+['You found me!']
 
 When we serialize the object,
 the path is
 stored relative to the directory
 of the YAML file.
 
-.. jupyter-execute::
-
-    import yaml
-
-
-    yaml_path = os.path.join(root, "yaml", "object.yaml")  # root/yaml/object.yaml
-    o.to_yaml(yaml_path)
-
-    with open(yaml_path, "r") as fp:
-        content = yaml.load(fp, Loader=yaml.Loader)
-    content
+>>> import yaml
+>>> yaml_path = os.path.join(root, "yaml", "object.yaml")  # root/yaml/object.yaml
+>>> o.to_yaml(yaml_path)
+>>> with open(yaml_path, "r") as fp:
+...     content = yaml.load(fp, Loader=yaml.Loader)
+>>> content
+{'$mypkg.MyObjectWithFile==1.0.0': {'path': '../re/source.txt'}}
 
 When we re-instantiate the object
 the path gets expanded again.
 
-.. jupyter-execute::
-
-    o2 = audobject.from_yaml(yaml_path)
-    o2.read()
+>>> o2 = audobject.from_yaml(yaml_path)
+>>> print(o2.path.endswith(os.path.join("root", "re", "source.txt")))
+True
+>>> with open(o2.path, "r") as fp:
+...     fp.readlines()
+['You found me!']
 
 This will also work from another location.
 Note that we have to move all referenced files as well,
 as their relative location to the YAML file must not change.
 
-.. jupyter-execute::
-
-    import shutil
-
-    new_root = os.path.join("some", "where", "else")
-    shutil.move(root, new_root)
-
-    yaml_path_new = os.path.join(new_root, "yaml", "object.yaml")
-    o3 = audobject.from_yaml(yaml_path_new)
-    o3.read()
+>>> import shutil
+>>> new_root = os.path.join("some", "where", "else")
+>>> _ = shutil.move(root, new_root)
+>>> yaml_path_new = os.path.join(new_root, "yaml", "object.yaml")
+>>> o3 = audobject.from_yaml(yaml_path_new)
+>>> print(o3.path.endswith(os.path.join("else", "re", "source.txt")))
+True
+>>> with open(o3.path, "r") as fp:
+...     fp.readlines()
+['You found me!']
 
 
 Serialize functions
@@ -636,9 +619,16 @@ can be used.
 It encodes the source code of the function
 and dynamically creates the function during decoding.
 
+.. note::
+    The examples in this section require function source code
+    to be stored in a real ``.py`` file,
+    so they are not executed as doctests here.
+
+.. skip: start
+
 The following class takes as arguments a function with two parameters.
 
-.. jupyter-execute::
+.. code-block:: python
 
     from collections.abc import Callable
 
@@ -661,7 +651,7 @@ The following class takes as arguments a function with two parameters.
 
 Here, we initialize an object with a function that sums up the two parameters.
 
-.. jupyter-execute::
+.. code-block:: python
 
     def add(a, b):
         return a + b
@@ -673,7 +663,7 @@ Here, we initialize an object with a function that sums up the two parameters.
 When we serialize the object,
 the definition of our function is stored in plain text.
 
-.. jupyter-execute::
+.. code-block:: python
 
     o_yaml = o.to_yaml_s()
     print(o_yaml)
@@ -681,21 +671,21 @@ the definition of our function is stored in plain text.
 From which the function can be dynamically initialized
 when the object is recreated.
 
-.. jupyter-execute::
+.. code-block:: python
 
     o2 = audobject.from_yaml_s(o_yaml)
     o2(2, 3)
 
 It also works for lambda expressions.
 
-.. jupyter-execute::
+.. code-block:: python
 
     o3 = MyObjectWithFunction(lambda a, b: a * b)
 
     o3_yaml = o3.to_yaml_s()
     print(o3_yaml)
 
-.. jupyter-execute::
+.. code-block:: python
 
     o4 = audobject.from_yaml_s(o3_yaml)
     o4(2, 3)
@@ -705,7 +695,7 @@ we can also pass a callable object
 that derives from
 :class:`audobject.Object`.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyCallableObject(audobject.Object):
 
@@ -727,17 +717,19 @@ In that case,
 the YAML representation is store
 instead of the function code.
 
-.. jupyter-execute::
+.. code-block:: python
 
     o5_yaml = o5.to_yaml_s()
     print(o5_yaml)
 
 And we can still restore the original object.
 
-.. jupyter-execute::
+.. code-block:: python
 
     o6 = audobject.from_yaml_s(o5_yaml)
     o6(4, 5)
+
+.. skip: end
 
 .. warning:: Since the described mechanism
     offers a way to execute arbitrary Python code,
@@ -750,7 +742,7 @@ Flat dictionary
 Let's create a class that takes
 as input a string, a list and a dictionary.
 
-.. jupyter-execute::
+.. code-block:: python
 
     class MyListDictObject(audobject.Object):
 
@@ -766,14 +758,20 @@ as input a string, a list and a dictionary.
 
 And initialize an object.
 
-.. jupyter-execute::
-
-    o = MyListDictObject(
-        a_str="test",
-        a_list=[1, "2", o],
-        a_dict={"pi": 3.1416, "e": 2.71828},
-    )
-    o.to_dict()
+>>> inner = MyObject("hello")
+>>> o = MyListDictObject(
+...     a_str="test",
+...     a_list=[1, "2", inner],
+...     a_dict={"pi": 3.1416, "e": 2.71828},
+... )
+>>> import pprint
+>>> pprint.pprint(o.to_dict())
+{'$mypkg.MyListDictObject==1.0.0': {'a_dict': {'e': 2.71828, 'pi': 3.1416},
+                                    'a_list': [1,
+                                               '2',
+                                               {'$mypkg.MyObject==1.0.0': {'num_repeat': 1,
+                                                                           'string': 'hello'}}],
+                                    'a_str': 'test'}}
 
 As expected, the dictionary of the object
 looks pretty nested.
@@ -783,9 +781,14 @@ this would not work.
 Therefore, in can sometimes be useful to
 get a flatten version of the dictionary.
 
-.. jupyter-execute::
-
-    o.to_dict(flatten=True)
+>>> pprint.pprint(o.to_dict(flatten=True))
+{'a_dict.e': 2.71828,
+ 'a_dict.pi': 3.1416,
+ 'a_list.0': 1,
+ 'a_list.1': '2',
+ 'a_list.2.num_repeat': 1,
+ 'a_list.2.string': 'hello',
+ 'a_str': 'test'}
 
 However, it's important to note that it's not possible
 to re-instantiate an object from a flattened dictionary.
@@ -800,27 +803,26 @@ with a different package version?
 
 Let's create another instance of ``MyObject``.
 
-.. jupyter-execute::
-
-    o = MyObject("I am a 1.0.0!", num_repeat=2)
-    print(o)
+>>> o = MyObject("I am a 1.0.0!", num_repeat=2)
+>>> print(o)
+I am a 1.0.0! I am a 1.0.0!
 
 And convert it to YAML.
 
-.. jupyter-execute::
-
-    o_yaml = o.to_yaml_s()
-    print(o_yaml)
+>>> o_yaml = o.to_yaml_s()
+>>> print(o_yaml)
+$mypkg.MyObject==1.0.0:
+  string: I am a 1.0.0!
+  num_repeat: 2
+<BLANKLINE>
 
 Loading it with a newer version of the package
 works without problems.
 
-.. jupyter-execute::
-
-    __version__ = "1.1.0"
-
-    o2 = audobject.from_yaml_s(o_yaml)
-    print(o2)
+>>> __version__ = "1.1.0"
+>>> o2 = audobject.from_yaml_s(o_yaml)
+>>> print(o2)
+I am a 1.0.0! I am a 1.0.0!
 
 But if we load it with an older version,
 a warning will be shown.
@@ -830,19 +832,30 @@ when the package version does not match
 by adjusting
 :attr:`audobject.config.PACKAGE_MISMATCH_WARN_LEVEL`.
 
-.. jupyter-execute::
-    :stderr:
+.. skip: next
+
+.. code-block:: python
 
     __version__ = "0.9.0"
 
     o3 = audobject.from_yaml_s(o_yaml)
     print(o3)
 
+.. Silently apply the old-version state for the rest of the section.
+
+.. invisible-code-block: python
+
+    __version__ = "0.9.0"
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o3 = audobject.from_yaml_s(o_yaml)
+
 Now we pretend that we update the package to ``2.0.0``.
 It includes a new version of ``MyObject``,
 with a slightly changed ``__str__`` function.
 
-.. jupyter-execute::
+.. code-block:: python
 
     __version__ = "2.0.0"
 
@@ -865,15 +878,14 @@ the object will be created without problems.
 However, when we print the object
 the strings are now separated by comma.
 
-.. jupyter-execute::
-
-    o3 = audobject.from_yaml_s(o_yaml)
-    print(o3)
+>>> o3 = audobject.from_yaml_s(o_yaml)
+>>> print(o3)
+I am a 1.0.0!,I am a 1.0.0!
 
 In the next release, we decide to introduce an argument
 that let the user set a custom delimiter.
 
-.. jupyter-execute::
+.. code-block:: python
 
     __version__ = "2.1.0"
 
@@ -898,17 +910,16 @@ we will get an error,
 because we are missing a value
 for the new argument.
 
-.. jupyter-execute::
-    :stderr:
-    :raises:
-
-    audobject.from_yaml_s(o_yaml)
+>>> audobject.from_yaml_s(o_yaml)
+Traceback (most recent call last):
+    ...
+RuntimeError: Missing mandatory arguments ['delimiter'] while instantiating <class 'mypkg.MyObject'> from version '1.0.0' when using version '2.1.0'.
 
 Since we want to be backward compatible,
 we decide to release a bug fix,
 where we initialize the new argument with a default value.
 
-.. jupyter-execute::
+.. code-block:: python
 
     __version__ = "2.1.1"
 
@@ -931,30 +942,32 @@ where we initialize the new argument with a default value.
 And in fact, it successfully creates the object again.
 It works, because it now has a default value for the missing argument.
 
-.. jupyter-execute::
-
-    o4 = audobject.from_yaml_s(o_yaml)
-    print(o4)
+>>> o4 = audobject.from_yaml_s(o_yaml)
+>>> print(o4)
+I am a 1.0.0! I am a 1.0.0!
 
 Finally, we will do it the other way round.
 Create an object with version ``2.1.1``.
 
-.. jupyter-execute::
-
-    o5 = MyObject("I am a 2.1.1!", num_repeat=2)
-    print(o5)
+>>> o5 = MyObject("I am a 2.1.1!", num_repeat=2)
+>>> print(o5)
+I am a 2.1.1! I am a 2.1.1!
 
 Convert it to YAML.
 
-.. jupyter-execute::
-
-    o5_yaml = o5.to_yaml_s()
-    print(o5_yaml)
+>>> o5_yaml = o5.to_yaml_s()
+>>> print(o5_yaml)
+$mypkg.MyObject==2.1.1:
+  string: I am a 2.1.1!
+  delimiter: ','
+  num_repeat: 2
+<BLANKLINE>
 
 And load it with ``1.0.0``.
 
-.. jupyter-execute::
-    :stderr:
+.. skip: next
+
+.. code-block:: python
 
     __version__ = "1.0.0"
 
@@ -975,6 +988,22 @@ And load it with ``1.0.0``.
     o6 = audobject.from_yaml_s(o5_yaml)
     print(o6)
 
+.. invisible-code-block: python
+
+    __version__ = "1.0.0"
+
+    class MyObject(audobject.Object):
+        def __init__(self, string, *, num_repeat=1):
+            self.string = string
+            self.num_repeat = num_repeat
+        def __str__(self):
+            return " ".join([self.string] * self.num_repeat)
+
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o6 = audobject.from_yaml_s(o5_yaml)
+
 In fact, it works, too.
 However, a warning is given that an argument was ignored.
 
@@ -984,42 +1013,61 @@ Dictionary
 :class:`audobject.Dictionary` implements a
 :class:`audobject.Object` that can used like a dictionary.
 
-.. jupyter-execute::
-
-    d = audobject.Dictionary(
-        string="I am a dictionary!",
-        pi=3.14159265359,
-    )
-    print(d)
+>>> d = audobject.Dictionary(
+...     string="I am a dictionary!",
+...     pi=3.14159265359,
+... )
+>>> print(d)
+$audobject.core.dictionary.Dictionary:
+  string: I am a dictionary!
+  pi: 3.14159265359
+<BLANKLINE>
 
 We can use ``[]`` notation to access the
 values of the dictionary.
 
-.. jupyter-execute::
-
-    d["string"] = "Still a dictionary!"
-    d["new"] = None
-    print(d)
+>>> d["string"] = "Still a dictionary!"
+>>> d["new"] = None
+>>> print(d)
+$audobject.core.dictionary.Dictionary:
+  string: Still a dictionary!
+  pi: 3.14159265359
+  new: null
+<BLANKLINE>
 
 And update from another dictionary.
 
-.. jupyter-execute::
-
-    d2 = audobject.Dictionary(
-        string="I will be a dictionary forever!",
-        object=MyObject("Hey, I am an object."),
-    )
-    d.update(d2)
-    print(d)
+>>> d2 = audobject.Dictionary(
+...     string="I will be a dictionary forever!",
+...     object=MyObject("Hey, I am an object."),
+... )
+>>> d.update(d2)
+>>> print(d)
+$audobject.core.dictionary.Dictionary:
+  string: I will be a dictionary forever!
+  pi: 3.14159265359
+  new: null
+  object:
+    $mypkg.MyObject:
+      string: Hey, I am an object.
+      num_repeat: 1
+<BLANKLINE>
 
 And we can read/write the dictionary from/to a file.
 
-.. jupyter-execute::
-
-    file = "dict.yaml"
-    d.to_yaml(file)
-    d3 = audobject.from_yaml(file)
-    print(d3)
+>>> file = "dict.yaml"
+>>> d.to_yaml(file)
+>>> d3 = audobject.from_yaml(file)
+>>> print(d3)
+$audobject.core.dictionary.Dictionary:
+  string: I will be a dictionary forever!
+  pi: 3.14159265359
+  new: null
+  object:
+    $mypkg.MyObject:
+      string: Hey, I am an object.
+      num_repeat: 1
+<BLANKLINE>
 
 Parameters
 ----------
@@ -1041,132 +1089,158 @@ And it can be bound a parameter to a specific versions.
 Let's pick up the previous example and define two parameters.
 A parameter that holds a string.
 
-.. jupyter-execute::
-
-    string = audobject.Parameter(
-        value_type=str,
-        description="the string we want to repeat",
-        value="bar",
-        choices=["bar", "Bar", "BAR"],
-    )
-    print(string)
+>>> string = audobject.Parameter(
+...     value_type=str,
+...     description="the string we want to repeat",
+...     value="bar",
+...     choices=["bar", "Bar", "BAR"],
+... )
+>>> print(string)
+$audobject.core.parameter.Parameter:
+  value_type: str
+  description: the string we want to repeat
+  value: bar
+  default_value: null
+  choices:
+  - bar
+  - Bar
+  - BAR
+  version: null
+<BLANKLINE>
 
 And a parameter that defines how many times we want to repeat the string.
 
-.. jupyter-execute::
-
-    repeat = audobject.Parameter(
-        value_type=int,
-        description="the number of times we want to repeat",
-        default_value=1,
-    )
-    print(repeat)
+>>> repeat = audobject.Parameter(
+...     value_type=int,
+...     description="the number of times we want to repeat",
+...     default_value=1,
+... )
+>>> print(repeat)
+$audobject.core.parameter.Parameter:
+  value_type: int
+  description: the number of times we want to repeat
+  value: 1
+  default_value: 1
+  choices: null
+  version: null
+<BLANKLINE>
 
 Now we combine the two parameters into a list.
 
-.. jupyter-execute::
-
-    params = audobject.Parameters(
-        string=string,
-        num_repeat=repeat,
-    )
-    print(params)
+>>> params = audobject.Parameters(
+...     string=string,
+...     num_repeat=repeat,
+... )
+>>> print(params)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  1      1        None                   the number of times we want to repeat  None
 
 If we call the list,
 we get a dictionary of parameter names and values.
 
-.. jupyter-execute::
-
-    params()
+>>> params()
+{'string': 'bar', 'num_repeat': 1}
 
 We can access the values of the parameters using ``.`` notation.
 
-.. jupyter-execute::
-
-    params.string = "BAR"
-    params.num_repeat = 2
-    print(params)
+>>> params.string = "BAR"
+>>> params.num_repeat = 2
+>>> print(params)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  2      1        None                   the number of times we want to repeat  None
 
 If we try to assign a value that is not in choices,
 we will get an error.
 
-.. jupyter-execute::
-    :stderr:
-    :raises:
-
-    params.string = "par"
+>>> params.string = "par"
+Traceback (most recent call last):
+    ...
+ValueError: Invalid value 'par', expected one of ['bar', 'Bar', 'BAR'].
 
 It is possible to assign a version (or a range of versions)
 to a parameter.
 
-.. jupyter-execute::
-
-    delim = audobject.Parameter(
-        value_type=str,
-        description="defines the delimiter",
-        default_value=",",
-        version=">=2.0.0,<3.0.0"
-    )
-    params["delimiter"] = delim
-    print(params)
+>>> delim = audobject.Parameter(
+...     value_type=str,
+...     description="defines the delimiter",
+...     default_value=",",
+...     version=">=2.0.0,<3.0.0"
+... )
+>>> params["delimiter"] = delim
+>>> print(params)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  2      1        None                   the number of times we want to repeat  None
+delimiter   ,      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 We can check if a parameter is available for a specific version.
 
-.. jupyter-execute::
-
-    "1.0.0" in delim, "2.4.0" in delim
+>>> "1.0.0" in delim, "2.4.0" in delim
+(False, True)
 
 We can also filter a list of parameters by version.
 
-.. jupyter-execute::
-
-    params_v3 = params.filter_by_version("3.0.0")
-    print(params_v3)
+>>> params_v3 = params.filter_by_version("3.0.0")
+>>> print(params_v3)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  2      1        None                   the number of times we want to repeat  None
 
 Or add them to a command line interface.
 
-.. jupyter-execute::
-
-    import argparse
-
-
-    parser = argparse.ArgumentParser()
-    params.to_command_line(parser)
-    print(parser.format_help())
+>>> import argparse
+>>> parser = argparse.ArgumentParser(prog="")
+>>> params.to_command_line(parser)
+>>> print(parser.format_help())
+usage:  [-h] [--string {bar,Bar,BAR}] [--num_repeat NUM_REPEAT]
+        [--delimiter DELIMITER]
+<BLANKLINE>
+options:
+  -h, --help            show this help message and exit
+  --string {bar,Bar,BAR}
+                        the string we want to repeat
+  --num_repeat NUM_REPEAT
+                        the number of times we want to repeat
+  --delimiter DELIMITER
+                        defines the delimiter (version: >=2.0.0,<3.0.0)
+<BLANKLINE>
 
 Or update the values from a command line interface.
 
-.. jupyter-execute::
-
-    args = parser.parse_args(
-        args=["--string=Bar", "--delimiter=;"]
-    )
-    params.from_command_line(args)
-    print(params)
+>>> args = parser.parse_args(
+...     args=["--string=Bar", "--delimiter=;"]
+... )
+>>> _ = params.from_command_line(args)
+>>> print(params)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  1      1        None                   the number of times we want to repeat  None
+delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 It is possible to convert it into a file path
 that keeps track of the parameters.
 
-.. jupyter-execute::
-
-    params.to_path(sort=True)
+>>> params.to_path(sort=True)
+'delimiter[;]/num_repeat[1]/string[Bar]'
 
 Last but not least, we can read/write the parameters from/to a file.
 
-.. jupyter-execute::
-
-    file = "params.yaml"
-    params.to_yaml(file)
-    params2 = audobject.from_yaml(file)
-    print(params2)
-
-.. reset working directory and clean up
-.. jupyter-execute::
-    :hide-code:
-
-    import shutil
-    os.chdir(_cwd_root)
-    shutil.rmtree(_tmp_root)
+>>> file = "params.yaml"
+>>> params.to_yaml(file)
+>>> params2 = audobject.from_yaml(file)
+>>> print(params2)
+Name        Value  Default  Choices                Description                            Version
+----        -----  -------  -------                -----------                            -------
+string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+num_repeat  1      1        None                   the number of times we want to repeat  None
+delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 .. _timedelta: https://docs.python.org/3/library/datetime.html#timedelta-objects
 .. _argparse: https://docs.python.org/3/library/argparse.html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -619,7 +619,7 @@ Here, we create a file and pass it to the object.
     >>> import os
     >>> import audeer
     >>> root = "root"
-    >>> res_path = os.path.join(root, "re", "source.txt")  # root/re/source.txt
+    >>> res_path = "root/re/source.txt"
     >>> _ = audeer.mkdir(os.path.dirname(res_path))
     >>> with open(res_path, "w") as fp:
     ...     _ = fp.write("You found me!")
@@ -636,12 +636,14 @@ of the YAML file.
 .. code-block:: pycon
 
     >>> import yaml
-    >>> yaml_path = os.path.join(root, "yaml", "object.yaml")  # root/yaml/object.yaml
+    >>> yaml_path = "root/yaml/object.yaml"
     >>> o.to_yaml(yaml_path)
     >>> with open(yaml_path, "r") as fp:
     ...     content = yaml.load(fp, Loader=yaml.Loader)
-    >>> content
-    {'$mypkg.MyObjectWithFile==1.0.0': {'path': '../re/source.txt'}}
+    >>> # Normalize separator for portable output across platforms
+    >>> path = content["$mypkg.MyObjectWithFile==1.0.0"]["path"]
+    >>> print(path.replace(os.sep, "/"))
+    ../re/source.txt
 
 When we re-instantiate the object
 the path gets expanded again.
@@ -1348,7 +1350,7 @@ that keeps track of the parameters.
 
 .. code-block:: pycon
 
-    >>> params.to_path(sort=True)
+    >>> params.to_path(delimiter="/", sort=True)
     'delimiter[;]/num_repeat[1]/string[Bar]'
 
 Last but not least, we can read/write the parameters from/to a file.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -225,7 +225,7 @@ with the :meth:`audobject.init_decorator` decorator.
                 print("LOG: print message")
             return " ".join([self.string] * self.num_repeat)
 
-If we set ``verbose=True``, debug message are printed.
+If we set ``verbose=True``, debug messages are printed.
 
 .. code-block:: pycon
 
@@ -779,7 +779,7 @@ that derives from
     18
 
 In that case,
-the YAML representation is store
+the YAML representation is stored
 instead of the function code.
 
 .. code-block:: pycon
@@ -849,8 +849,8 @@ looks pretty nested.
 This is not always handy,
 e.g. if we try to store the object to a lookup table,
 this would not work.
-Therefore, in can sometimes be useful to
-get a flatten version of the dictionary.
+Therefore, it can sometimes be useful to
+get a flattened version of the dictionary.
 
 .. code-block:: pycon
 
@@ -964,7 +964,7 @@ the strings are now separated by comma.
     I am a 1.0.0!,I am a 1.0.0!
 
 In the next release, we decide to introduce an argument
-that let the user set a custom delimiter.
+that lets the user set a custom delimiter.
 
 .. code-block:: python
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,9 +32,11 @@ Let's create a class that derives from :class:`audobject.Object`.
 
 Now we instantiate an object and print it.
 
->>> o = MyObject("hello object!", num_repeat=2)
->>> print(o)
-hello object! hello object!
+.. code-block:: pycon
+
+    >>> o = MyObject("hello object!", num_repeat=2)
+    >>> print(o)
+    hello object! hello object!
 
 As expected we see that ``string`` is repeated ``num_repeat`` times.
 But since we derived from :class:`audobject.Object`
@@ -43,83 +45,105 @@ we get some additional functionality.
 For instance, we can get a dictionary
 with the arguments the object was initialized with.
 
->>> o.arguments
-{'string': 'hello object!', 'num_repeat': 2}
+.. code-block:: pycon
+
+    >>> o.arguments
+    {'string': 'hello object!', 'num_repeat': 2}
 
 Or a dictionary that also stores module,
 object name and package version.
 
->>> o_dict = o.to_dict()
->>> print(o_dict)
-{'$mypkg.MyObject==1.0.0': {'string': 'hello object!', 'num_repeat': 2}}
+.. code-block:: pycon
+
+    >>> o_dict = o.to_dict()
+    >>> print(o_dict)
+    {'$mypkg.MyObject==1.0.0': {'string': 'hello object!', 'num_repeat': 2}}
 
 And we can re-instantiate the object from it.
 
->>> o2 = audobject.from_dict(o_dict)
->>> print(o2)
-hello object! hello object!
+.. code-block:: pycon
+
+    >>> o2 = audobject.from_dict(o_dict)
+    >>> print(o2)
+    hello object! hello object!
 
 We can also convert it to YAML.
 
->>> o_yaml = o.to_yaml_s()
->>> print(o_yaml)
-$mypkg.MyObject==1.0.0:
-  string: hello object!
-  num_repeat: 2
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o_yaml = o.to_yaml_s()
+    >>> print(o_yaml)
+    $mypkg.MyObject==1.0.0:
+      string: hello object!
+      num_repeat: 2
+    <BLANKLINE>
 
 And create the object from YAML.
 
->>> o3 = audobject.from_yaml_s(o_yaml)
->>> print(o3)
-hello object! hello object!
+.. code-block:: pycon
+
+    >>> o3 = audobject.from_yaml_s(o_yaml)
+    >>> print(o3)
+    hello object! hello object!
 
 If we want, we can override
 arguments when we instantiate an object.
 
->>> o4 = audobject.from_yaml_s(
-...     o_yaml,
-...     override_args={
-...         "string": "I was set to a different value!"
-...     }
-... )
->>> print(o4)
-I was set to a different value! I was set to a different value!
+.. code-block:: pycon
+
+    >>> o4 = audobject.from_yaml_s(
+    ...     o_yaml,
+    ...     override_args={
+    ...         "string": "I was set to a different value!"
+    ...     }
+    ... )
+    >>> print(o4)
+    I was set to a different value! I was set to a different value!
 
 Or save an object to disk and re-instantiate it from there.
 
->>> file = "my.yaml"
->>> o.to_yaml(file)
->>> o5 = audobject.from_yaml(file)
->>> print(o5)
-hello object! hello object!
+.. code-block:: pycon
+
+    >>> file = "my.yaml"
+    >>> o.to_yaml(file)
+    >>> o5 = audobject.from_yaml(file)
+    >>> print(o5)
+    hello object! hello object!
 
 Object ID
 ---------
 
 Every object has an ID.
 
->>> o = MyObject("I am unique!", num_repeat=2)
->>> print(o.id)
-9268115e-7caf-aa02-7fbb-da4e83b2f575
+.. code-block:: pycon
+
+    >>> o = MyObject("I am unique!", num_repeat=2)
+    >>> print(o.id)
+    9268115e-7caf-aa02-7fbb-da4e83b2f575
 
 Objects with exact same arguments share the same ID.
 
->>> o2 = MyObject("I am unique!", num_repeat=2)
->>> print(o.id == o2.id)
-True
+.. code-block:: pycon
+
+    >>> o2 = MyObject("I am unique!", num_repeat=2)
+    >>> print(o.id == o2.id)
+    True
 
 When an object is serialized the ID does not change.
 
->>> o3 = audobject.from_yaml_s(o.to_yaml_s())
->>> print(o3.id == o.id)
-True
+.. code-block:: pycon
+
+    >>> o3 = audobject.from_yaml_s(o.to_yaml_s())
+    >>> print(o3.id == o.id)
+    True
 
 Objects with different arguments get different IDs.
 
->>> o4 = MyObject("I am different!", num_repeat=2)
->>> print(o.id == o4.id)
-False
+.. code-block:: pycon
+
+    >>> o4 = MyObject("I am different!", num_repeat=2)
+    >>> print(o.id == o4.id)
+    False
 
 Malformed objects
 -----------------
@@ -147,17 +171,21 @@ Let's create a class where we don't follow this rule.
 
 At a first glance, everything works as expected.
 
->>> bad = MyBadObject("test", num_repeat=2)
->>> print(bad)
-test test
+.. code-block:: pycon
+
+    >>> bad = MyBadObject("test", num_repeat=2)
+    >>> print(bad)
+    test test
 
 But if we try to serialize the object to YAML,
 we'll get an error.
 
->>> bad.to_yaml_s()
-Traceback (most recent call last):
-    ...
-RuntimeError: Arguments ['string', 'num_repeat'] of <class 'mypkg.MyBadObject'> not assigned to attributes of same name.
+.. code-block:: pycon
+
+    >>> bad.to_yaml_s()
+    Traceback (most recent call last):
+        ...
+    RuntimeError: Arguments ['string', 'num_repeat'] of <class 'mypkg.MyBadObject'> not assigned to attributes of same name.
 
 However, in the next section we'll learn
 that it's possible to hide arguments.
@@ -199,57 +227,69 @@ with the :meth:`audobject.init_decorator` decorator.
 
 If we set ``verbose=True``, debug message are printed.
 
->>> o = MyObjectWithHiddenArgument(
-...     "hello object!",
-...     num_repeat=3,
-...     verbose=True,
-... )
->>> print(o)
-LOG: print message
-hello object! hello object! hello object!
+.. code-block:: pycon
+
+    >>> o = MyObjectWithHiddenArgument(
+    ...     "hello object!",
+    ...     num_repeat=3,
+    ...     verbose=True,
+    ... )
+    >>> print(o)
+    LOG: print message
+    hello object! hello object! hello object!
 
 But since ``verbose`` is a hidden argument,
 it is not stored to YAML.
 
->>> o_yaml = o.to_yaml_s()
->>> print(o_yaml)
-$mypkg.MyObjectWithHiddenArgument==1.0.0:
-  string: hello object!
-  num_repeat: 3
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o_yaml = o.to_yaml_s()
+    >>> print(o_yaml)
+    $mypkg.MyObjectWithHiddenArgument==1.0.0:
+      string: hello object!
+      num_repeat: 3
+    <BLANKLINE>
 
 That means when we re-instantiate the object,
 ``verbose`` will be set to its default value (``False``)
 and we won't see debug messages.
 
->>> o2 = audobject.from_yaml_s(o_yaml)
->>> print(o2)
-hello object! hello object! hello object!
+.. code-block:: pycon
+
+    >>> o2 = audobject.from_yaml_s(o_yaml)
+    >>> print(o2)
+    hello object! hello object! hello object!
 
 However, we can still set ``verbose``
 to ``True`` when we load the object.
 
->>> o3 = audobject.from_yaml_s(
-...     o_yaml,
-...     override_args={
-...         "verbose": True,
-...     }
-... )
->>> print(o3)
-LOG: print message
-hello object! hello object! hello object!
+.. code-block:: pycon
+
+    >>> o3 = audobject.from_yaml_s(
+    ...     o_yaml,
+    ...     override_args={
+    ...         "verbose": True,
+    ...     }
+    ... )
+    >>> print(o3)
+    LOG: print message
+    hello object! hello object! hello object!
 
 Note that hidden arguments are not taken into account for the UID.
 
->>> print(o2.id)
-26eddeb8-2ead-69e1-0eb2-37c2a2d19174
->>> print(o3.id)
-26eddeb8-2ead-69e1-0eb2-37c2a2d19174
+.. code-block:: pycon
+
+    >>> print(o2.id)
+    26eddeb8-2ead-69e1-0eb2-37c2a2d19174
+    >>> print(o3.id)
+    26eddeb8-2ead-69e1-0eb2-37c2a2d19174
 
 It is possible to get a list of hidden arguments.
 
->>> o3.hidden_arguments
-['verbose']
+.. code-block:: pycon
+
+    >>> o3.hidden_arguments
+    ['verbose']
 
 Borrowed arguments
 ------------------
@@ -295,13 +335,15 @@ to add properties with the name of an argument.
         def z(self):  # property sharing the name of an argument
             return self.d["z"]
 
->>> o = ObjectWithBorrowedArguments(0, 1, 2)
->>> print(o.to_yaml_s())
-$mypkg.ObjectWithBorrowedArguments==1.0.0:
-  x: 0
-  y: 1
-  z: 2
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o = ObjectWithBorrowedArguments(0, 1, 2)
+    >>> print(o.to_yaml_s())
+    $mypkg.ObjectWithBorrowedArguments==1.0.0:
+      x: 0
+      y: 1
+      z: 2
+    <BLANKLINE>
 
 Object with kwargs
 ------------------
@@ -330,20 +372,24 @@ from the signature of the function.
         def __str__(self) -> str:
             return " ".join([self.string] * self.num_repeat)
 
->>> o = MyObjectWithKwargs("I have kwargs", num_repeat=3)
->>> print(o)
-I have kwargs I have kwargs I have kwargs
+.. code-block:: pycon
+
+    >>> o = MyObjectWithKwargs("I have kwargs", num_repeat=3)
+    >>> print(o)
+    I have kwargs I have kwargs I have kwargs
 
 When we serialize the object,
 we see that keyword argument
 ``num_repeat`` will be included.
 
->>> o_yaml = o.to_yaml_s()
->>> print(o_yaml)
-$mypkg.MyObjectWithKwargs==1.0.0:
-  string: I have kwargs
-  num_repeat: 3
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o_yaml = o.to_yaml_s()
+    >>> print(o_yaml)
+    $mypkg.MyObjectWithKwargs==1.0.0:
+      string: I have kwargs
+      num_repeat: 3
+    <BLANKLINE>
 
 Object as argument
 ------------------
@@ -367,27 +413,33 @@ For instance, we can define the following class.
 
 And initialize it with an instance of ``MyObject``.
 
->>> o = MyObject("eat me!")
->>> w = MySuperObject(o)
->>> print(w)
-[eat me!]
+.. code-block:: pycon
+
+    >>> o = MyObject("eat me!")
+    >>> w = MySuperObject(o)
+    >>> print(w)
+    [eat me!]
 
 This translates to the following YAML string.
 
->>> w_yaml = w.to_yaml_s()
->>> print(w_yaml)
-$mypkg.MySuperObject==1.0.0:
-  obj:
-    $mypkg.MyObject==1.0.0:
-      string: eat me!
-      num_repeat: 1
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> w_yaml = w.to_yaml_s()
+    >>> print(w_yaml)
+    $mypkg.MySuperObject==1.0.0:
+      obj:
+        $mypkg.MyObject==1.0.0:
+          string: eat me!
+          num_repeat: 1
+    <BLANKLINE>
 
 From which we can re-instantiate the object.
 
->>> w2 = audobject.from_yaml_s(w_yaml)
->>> print(w2)
-[eat me!]
+.. code-block:: pycon
+
+    >>> w2 = audobject.from_yaml_s(w_yaml)
+    >>> print(w2)
+    [eat me!]
 
 Value resolver
 --------------
@@ -429,18 +481,20 @@ To illustrate this, let's use an instance of timedelta_.
 
 As before, we can create an instance and print it.
 
->>> delta = timedelta(
-...     days=50,
-...     seconds=27,
-...     microseconds=10,
-...     milliseconds=29000,
-...     minutes=5,
-...     hours=8,
-...     weeks=2
-... )
->>> d = MyDeltaObject(delta)
->>> print(d)
-64 days, 8:05:56.000010
+.. code-block:: pycon
+
+    >>> delta = timedelta(
+    ...     days=50,
+    ...     seconds=27,
+    ...     microseconds=10,
+    ...     milliseconds=29000,
+    ...     minutes=5,
+    ...     hours=8,
+    ...     weeks=2
+    ... )
+    >>> d = MyDeltaObject(delta)
+    >>> print(d)
+    64 days, 8:05:56.000010
 
 But if we convert it to YAML,
 we'll see a warning.
@@ -510,15 +564,17 @@ decorator of the ``__init__`` function.
 Now, we don't get a warning
 and the ``!!python/object`` tag has disappeared.
 
->>> d = MyResolvedDeltaObject(delta)
->>> d_yaml = d.to_yaml_s()
->>> print(d_yaml)
-$mypkg.MyResolvedDeltaObject==1.0.0:
-  delta:
-    days: 64
-    seconds: 29156
-    microseconds: 10
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> d = MyResolvedDeltaObject(delta)
+    >>> d_yaml = d.to_yaml_s()
+    >>> print(d_yaml)
+    $mypkg.MyResolvedDeltaObject==1.0.0:
+      delta:
+        days: 64
+        seconds: 29156
+        microseconds: 10
+    <BLANKLINE>
 
 Resolve file paths
 ------------------
@@ -558,55 +614,63 @@ This can be achieved using
 
 Here, we create a file and pass it to the object.
 
->>> import os
->>> import audeer
->>> root = "root"
->>> res_path = os.path.join(root, "re", "source.txt")  # root/re/source.txt
->>> _ = audeer.mkdir(os.path.dirname(res_path))
->>> with open(res_path, "w") as fp:
-...     _ = fp.write("You found me!")
->>> o = MyObjectWithFile(res_path)
->>> o.read()
-root/re/source.txt
-['You found me!']
+.. code-block:: pycon
+
+    >>> import os
+    >>> import audeer
+    >>> root = "root"
+    >>> res_path = os.path.join(root, "re", "source.txt")  # root/re/source.txt
+    >>> _ = audeer.mkdir(os.path.dirname(res_path))
+    >>> with open(res_path, "w") as fp:
+    ...     _ = fp.write("You found me!")
+    >>> o = MyObjectWithFile(res_path)
+    >>> o.read()
+    root/re/source.txt
+    ['You found me!']
 
 When we serialize the object,
 the path is
 stored relative to the directory
 of the YAML file.
 
->>> import yaml
->>> yaml_path = os.path.join(root, "yaml", "object.yaml")  # root/yaml/object.yaml
->>> o.to_yaml(yaml_path)
->>> with open(yaml_path, "r") as fp:
-...     content = yaml.load(fp, Loader=yaml.Loader)
->>> content
-{'$mypkg.MyObjectWithFile==1.0.0': {'path': '../re/source.txt'}}
+.. code-block:: pycon
+
+    >>> import yaml
+    >>> yaml_path = os.path.join(root, "yaml", "object.yaml")  # root/yaml/object.yaml
+    >>> o.to_yaml(yaml_path)
+    >>> with open(yaml_path, "r") as fp:
+    ...     content = yaml.load(fp, Loader=yaml.Loader)
+    >>> content
+    {'$mypkg.MyObjectWithFile==1.0.0': {'path': '../re/source.txt'}}
 
 When we re-instantiate the object
 the path gets expanded again.
 
->>> o2 = audobject.from_yaml(yaml_path)
->>> print(o2.path.endswith(os.path.join("root", "re", "source.txt")))
-True
->>> with open(o2.path, "r") as fp:
-...     fp.readlines()
-['You found me!']
+.. code-block:: pycon
+
+    >>> o2 = audobject.from_yaml(yaml_path)
+    >>> print(o2.path.endswith(os.path.join("root", "re", "source.txt")))
+    True
+    >>> with open(o2.path, "r") as fp:
+    ...     fp.readlines()
+    ['You found me!']
 
 This will also work from another location.
 Note that we have to move all referenced files as well,
 as their relative location to the YAML file must not change.
 
->>> import shutil
->>> new_root = os.path.join("some", "where", "else")
->>> _ = shutil.move(root, new_root)
->>> yaml_path_new = os.path.join(new_root, "yaml", "object.yaml")
->>> o3 = audobject.from_yaml(yaml_path_new)
->>> print(o3.path.endswith(os.path.join("else", "re", "source.txt")))
-True
->>> with open(o3.path, "r") as fp:
-...     fp.readlines()
-['You found me!']
+.. code-block:: pycon
+
+    >>> import shutil
+    >>> new_root = os.path.join("some", "where", "else")
+    >>> _ = shutil.move(root, new_root)
+    >>> yaml_path_new = os.path.join(new_root, "yaml", "object.yaml")
+    >>> o3 = audobject.from_yaml(yaml_path_new)
+    >>> print(o3.path.endswith(os.path.join("else", "re", "source.txt")))
+    True
+    >>> with open(o3.path, "r") as fp:
+    ...     fp.readlines()
+    ['You found me!']
 
 
 Serialize functions
@@ -758,20 +822,22 @@ as input a string, a list and a dictionary.
 
 And initialize an object.
 
->>> inner = MyObject("hello")
->>> o = MyListDictObject(
-...     a_str="test",
-...     a_list=[1, "2", inner],
-...     a_dict={"pi": 3.1416, "e": 2.71828},
-... )
->>> import pprint
->>> pprint.pprint(o.to_dict())
-{'$mypkg.MyListDictObject==1.0.0': {'a_dict': {'e': 2.71828, 'pi': 3.1416},
-                                    'a_list': [1,
-                                               '2',
-                                               {'$mypkg.MyObject==1.0.0': {'num_repeat': 1,
-                                                                           'string': 'hello'}}],
-                                    'a_str': 'test'}}
+.. code-block:: pycon
+
+    >>> inner = MyObject("hello")
+    >>> o = MyListDictObject(
+    ...     a_str="test",
+    ...     a_list=[1, "2", inner],
+    ...     a_dict={"pi": 3.1416, "e": 2.71828},
+    ... )
+    >>> import pprint
+    >>> pprint.pprint(o.to_dict())
+    {'$mypkg.MyListDictObject==1.0.0': {'a_dict': {'e': 2.71828, 'pi': 3.1416},
+                                        'a_list': [1,
+                                                   '2',
+                                                   {'$mypkg.MyObject==1.0.0': {'num_repeat': 1,
+                                                                               'string': 'hello'}}],
+                                        'a_str': 'test'}}
 
 As expected, the dictionary of the object
 looks pretty nested.
@@ -781,14 +847,16 @@ this would not work.
 Therefore, in can sometimes be useful to
 get a flatten version of the dictionary.
 
->>> pprint.pprint(o.to_dict(flatten=True))
-{'a_dict.e': 2.71828,
- 'a_dict.pi': 3.1416,
- 'a_list.0': 1,
- 'a_list.1': '2',
- 'a_list.2.num_repeat': 1,
- 'a_list.2.string': 'hello',
- 'a_str': 'test'}
+.. code-block:: pycon
+
+    >>> pprint.pprint(o.to_dict(flatten=True))
+    {'a_dict.e': 2.71828,
+     'a_dict.pi': 3.1416,
+     'a_list.0': 1,
+     'a_list.1': '2',
+     'a_list.2.num_repeat': 1,
+     'a_list.2.string': 'hello',
+     'a_str': 'test'}
 
 However, it's important to note that it's not possible
 to re-instantiate an object from a flattened dictionary.
@@ -803,26 +871,32 @@ with a different package version?
 
 Let's create another instance of ``MyObject``.
 
->>> o = MyObject("I am a 1.0.0!", num_repeat=2)
->>> print(o)
-I am a 1.0.0! I am a 1.0.0!
+.. code-block:: pycon
+
+    >>> o = MyObject("I am a 1.0.0!", num_repeat=2)
+    >>> print(o)
+    I am a 1.0.0! I am a 1.0.0!
 
 And convert it to YAML.
 
->>> o_yaml = o.to_yaml_s()
->>> print(o_yaml)
-$mypkg.MyObject==1.0.0:
-  string: I am a 1.0.0!
-  num_repeat: 2
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o_yaml = o.to_yaml_s()
+    >>> print(o_yaml)
+    $mypkg.MyObject==1.0.0:
+      string: I am a 1.0.0!
+      num_repeat: 2
+    <BLANKLINE>
 
 Loading it with a newer version of the package
 works without problems.
 
->>> __version__ = "1.1.0"
->>> o2 = audobject.from_yaml_s(o_yaml)
->>> print(o2)
-I am a 1.0.0! I am a 1.0.0!
+.. code-block:: pycon
+
+    >>> __version__ = "1.1.0"
+    >>> o2 = audobject.from_yaml_s(o_yaml)
+    >>> print(o2)
+    I am a 1.0.0! I am a 1.0.0!
 
 But if we load it with an older version,
 a warning will be shown.
@@ -878,9 +952,11 @@ the object will be created without problems.
 However, when we print the object
 the strings are now separated by comma.
 
->>> o3 = audobject.from_yaml_s(o_yaml)
->>> print(o3)
-I am a 1.0.0!,I am a 1.0.0!
+.. code-block:: pycon
+
+    >>> o3 = audobject.from_yaml_s(o_yaml)
+    >>> print(o3)
+    I am a 1.0.0!,I am a 1.0.0!
 
 In the next release, we decide to introduce an argument
 that let the user set a custom delimiter.
@@ -910,10 +986,12 @@ we will get an error,
 because we are missing a value
 for the new argument.
 
->>> audobject.from_yaml_s(o_yaml)
-Traceback (most recent call last):
-    ...
-RuntimeError: Missing mandatory arguments ['delimiter'] while instantiating <class 'mypkg.MyObject'> from version '1.0.0' when using version '2.1.0'.
+.. code-block:: pycon
+
+    >>> audobject.from_yaml_s(o_yaml)
+    Traceback (most recent call last):
+        ...
+    RuntimeError: Missing mandatory arguments ['delimiter'] while instantiating <class 'mypkg.MyObject'> from version '1.0.0' when using version '2.1.0'.
 
 Since we want to be backward compatible,
 we decide to release a bug fix,
@@ -942,26 +1020,32 @@ where we initialize the new argument with a default value.
 And in fact, it successfully creates the object again.
 It works, because it now has a default value for the missing argument.
 
->>> o4 = audobject.from_yaml_s(o_yaml)
->>> print(o4)
-I am a 1.0.0! I am a 1.0.0!
+.. code-block:: pycon
+
+    >>> o4 = audobject.from_yaml_s(o_yaml)
+    >>> print(o4)
+    I am a 1.0.0! I am a 1.0.0!
 
 Finally, we will do it the other way round.
 Create an object with version ``2.1.1``.
 
->>> o5 = MyObject("I am a 2.1.1!", num_repeat=2)
->>> print(o5)
-I am a 2.1.1! I am a 2.1.1!
+.. code-block:: pycon
+
+    >>> o5 = MyObject("I am a 2.1.1!", num_repeat=2)
+    >>> print(o5)
+    I am a 2.1.1! I am a 2.1.1!
 
 Convert it to YAML.
 
->>> o5_yaml = o5.to_yaml_s()
->>> print(o5_yaml)
-$mypkg.MyObject==2.1.1:
-  string: I am a 2.1.1!
-  delimiter: ','
-  num_repeat: 2
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> o5_yaml = o5.to_yaml_s()
+    >>> print(o5_yaml)
+    $mypkg.MyObject==2.1.1:
+      string: I am a 2.1.1!
+      delimiter: ','
+      num_repeat: 2
+    <BLANKLINE>
 
 And load it with ``1.0.0``.
 
@@ -1013,61 +1097,69 @@ Dictionary
 :class:`audobject.Dictionary` implements a
 :class:`audobject.Object` that can used like a dictionary.
 
->>> d = audobject.Dictionary(
-...     string="I am a dictionary!",
-...     pi=3.14159265359,
-... )
->>> print(d)
-$audobject.core.dictionary.Dictionary:
-  string: I am a dictionary!
-  pi: 3.14159265359
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> d = audobject.Dictionary(
+    ...     string="I am a dictionary!",
+    ...     pi=3.14159265359,
+    ... )
+    >>> print(d)
+    $audobject.core.dictionary.Dictionary:
+      string: I am a dictionary!
+      pi: 3.14159265359
+    <BLANKLINE>
 
 We can use ``[]`` notation to access the
 values of the dictionary.
 
->>> d["string"] = "Still a dictionary!"
->>> d["new"] = None
->>> print(d)
-$audobject.core.dictionary.Dictionary:
-  string: Still a dictionary!
-  pi: 3.14159265359
-  new: null
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> d["string"] = "Still a dictionary!"
+    >>> d["new"] = None
+    >>> print(d)
+    $audobject.core.dictionary.Dictionary:
+      string: Still a dictionary!
+      pi: 3.14159265359
+      new: null
+    <BLANKLINE>
 
 And update from another dictionary.
 
->>> d2 = audobject.Dictionary(
-...     string="I will be a dictionary forever!",
-...     object=MyObject("Hey, I am an object."),
-... )
->>> d.update(d2)
->>> print(d)
-$audobject.core.dictionary.Dictionary:
-  string: I will be a dictionary forever!
-  pi: 3.14159265359
-  new: null
-  object:
-    $mypkg.MyObject:
-      string: Hey, I am an object.
-      num_repeat: 1
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> d2 = audobject.Dictionary(
+    ...     string="I will be a dictionary forever!",
+    ...     object=MyObject("Hey, I am an object."),
+    ... )
+    >>> d.update(d2)
+    >>> print(d)
+    $audobject.core.dictionary.Dictionary:
+      string: I will be a dictionary forever!
+      pi: 3.14159265359
+      new: null
+      object:
+        $mypkg.MyObject:
+          string: Hey, I am an object.
+          num_repeat: 1
+    <BLANKLINE>
 
 And we can read/write the dictionary from/to a file.
 
->>> file = "dict.yaml"
->>> d.to_yaml(file)
->>> d3 = audobject.from_yaml(file)
->>> print(d3)
-$audobject.core.dictionary.Dictionary:
-  string: I will be a dictionary forever!
-  pi: 3.14159265359
-  new: null
-  object:
-    $mypkg.MyObject:
-      string: Hey, I am an object.
-      num_repeat: 1
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> file = "dict.yaml"
+    >>> d.to_yaml(file)
+    >>> d3 = audobject.from_yaml(file)
+    >>> print(d3)
+    $audobject.core.dictionary.Dictionary:
+      string: I will be a dictionary forever!
+      pi: 3.14159265359
+      new: null
+      object:
+        $mypkg.MyObject:
+          string: Hey, I am an object.
+          num_repeat: 1
+    <BLANKLINE>
 
 Parameters
 ----------
@@ -1089,158 +1181,184 @@ And it can be bound a parameter to a specific versions.
 Let's pick up the previous example and define two parameters.
 A parameter that holds a string.
 
->>> string = audobject.Parameter(
-...     value_type=str,
-...     description="the string we want to repeat",
-...     value="bar",
-...     choices=["bar", "Bar", "BAR"],
-... )
->>> print(string)
-$audobject.core.parameter.Parameter:
-  value_type: str
-  description: the string we want to repeat
-  value: bar
-  default_value: null
-  choices:
-  - bar
-  - Bar
-  - BAR
-  version: null
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> string = audobject.Parameter(
+    ...     value_type=str,
+    ...     description="the string we want to repeat",
+    ...     value="bar",
+    ...     choices=["bar", "Bar", "BAR"],
+    ... )
+    >>> print(string)
+    $audobject.core.parameter.Parameter:
+      value_type: str
+      description: the string we want to repeat
+      value: bar
+      default_value: null
+      choices:
+      - bar
+      - Bar
+      - BAR
+      version: null
+    <BLANKLINE>
 
 And a parameter that defines how many times we want to repeat the string.
 
->>> repeat = audobject.Parameter(
-...     value_type=int,
-...     description="the number of times we want to repeat",
-...     default_value=1,
-... )
->>> print(repeat)
-$audobject.core.parameter.Parameter:
-  value_type: int
-  description: the number of times we want to repeat
-  value: 1
-  default_value: 1
-  choices: null
-  version: null
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> repeat = audobject.Parameter(
+    ...     value_type=int,
+    ...     description="the number of times we want to repeat",
+    ...     default_value=1,
+    ... )
+    >>> print(repeat)
+    $audobject.core.parameter.Parameter:
+      value_type: int
+      description: the number of times we want to repeat
+      value: 1
+      default_value: 1
+      choices: null
+      version: null
+    <BLANKLINE>
 
 Now we combine the two parameters into a list.
 
->>> params = audobject.Parameters(
-...     string=string,
-...     num_repeat=repeat,
-... )
->>> print(params)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  1      1        None                   the number of times we want to repeat  None
+.. code-block:: pycon
+
+    >>> params = audobject.Parameters(
+    ...     string=string,
+    ...     num_repeat=repeat,
+    ... )
+    >>> print(params)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  1      1        None                   the number of times we want to repeat  None
 
 If we call the list,
 we get a dictionary of parameter names and values.
 
->>> params()
-{'string': 'bar', 'num_repeat': 1}
+.. code-block:: pycon
+
+    >>> params()
+    {'string': 'bar', 'num_repeat': 1}
 
 We can access the values of the parameters using ``.`` notation.
 
->>> params.string = "BAR"
->>> params.num_repeat = 2
->>> print(params)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  2      1        None                   the number of times we want to repeat  None
+.. code-block:: pycon
+
+    >>> params.string = "BAR"
+    >>> params.num_repeat = 2
+    >>> print(params)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  2      1        None                   the number of times we want to repeat  None
 
 If we try to assign a value that is not in choices,
 we will get an error.
 
->>> params.string = "par"
-Traceback (most recent call last):
-    ...
-ValueError: Invalid value 'par', expected one of ['bar', 'Bar', 'BAR'].
+.. code-block:: pycon
+
+    >>> params.string = "par"
+    Traceback (most recent call last):
+        ...
+    ValueError: Invalid value 'par', expected one of ['bar', 'Bar', 'BAR'].
 
 It is possible to assign a version (or a range of versions)
 to a parameter.
 
->>> delim = audobject.Parameter(
-...     value_type=str,
-...     description="defines the delimiter",
-...     default_value=",",
-...     version=">=2.0.0,<3.0.0"
-... )
->>> params["delimiter"] = delim
->>> print(params)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  2      1        None                   the number of times we want to repeat  None
-delimiter   ,      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
+.. code-block:: pycon
+
+    >>> delim = audobject.Parameter(
+    ...     value_type=str,
+    ...     description="defines the delimiter",
+    ...     default_value=",",
+    ...     version=">=2.0.0,<3.0.0"
+    ... )
+    >>> params["delimiter"] = delim
+    >>> print(params)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  2      1        None                   the number of times we want to repeat  None
+    delimiter   ,      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 We can check if a parameter is available for a specific version.
 
->>> "1.0.0" in delim, "2.4.0" in delim
-(False, True)
+.. code-block:: pycon
+
+    >>> "1.0.0" in delim, "2.4.0" in delim
+    (False, True)
 
 We can also filter a list of parameters by version.
 
->>> params_v3 = params.filter_by_version("3.0.0")
->>> print(params_v3)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  2      1        None                   the number of times we want to repeat  None
+.. code-block:: pycon
+
+    >>> params_v3 = params.filter_by_version("3.0.0")
+    >>> print(params_v3)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      BAR    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  2      1        None                   the number of times we want to repeat  None
 
 Or add them to a command line interface.
 
->>> import argparse
->>> parser = argparse.ArgumentParser(prog="")
->>> params.to_command_line(parser)
->>> print(parser.format_help())
-usage:  [-h] [--string {bar,Bar,BAR}] [--num_repeat NUM_REPEAT]
-        [--delimiter DELIMITER]
-<BLANKLINE>
-options:
-  -h, --help            show this help message and exit
-  --string {bar,Bar,BAR}
-                        the string we want to repeat
-  --num_repeat NUM_REPEAT
-                        the number of times we want to repeat
-  --delimiter DELIMITER
-                        defines the delimiter (version: >=2.0.0,<3.0.0)
-<BLANKLINE>
+.. code-block:: pycon
+
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser(prog="")
+    >>> params.to_command_line(parser)
+    >>> print(parser.format_help())
+    usage:  [-h] [--string {bar,Bar,BAR}] [--num_repeat NUM_REPEAT]
+            [--delimiter DELIMITER]
+    <BLANKLINE>
+    options:
+      -h, --help            show this help message and exit
+      --string {bar,Bar,BAR}
+                            the string we want to repeat
+      --num_repeat NUM_REPEAT
+                            the number of times we want to repeat
+      --delimiter DELIMITER
+                            defines the delimiter (version: >=2.0.0,<3.0.0)
+    <BLANKLINE>
 
 Or update the values from a command line interface.
 
->>> args = parser.parse_args(
-...     args=["--string=Bar", "--delimiter=;"]
-... )
->>> _ = params.from_command_line(args)
->>> print(params)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  1      1        None                   the number of times we want to repeat  None
-delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
+.. code-block:: pycon
+
+    >>> args = parser.parse_args(
+    ...     args=["--string=Bar", "--delimiter=;"]
+    ... )
+    >>> _ = params.from_command_line(args)
+    >>> print(params)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  1      1        None                   the number of times we want to repeat  None
+    delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 It is possible to convert it into a file path
 that keeps track of the parameters.
 
->>> params.to_path(sort=True)
-'delimiter[;]/num_repeat[1]/string[Bar]'
+.. code-block:: pycon
+
+    >>> params.to_path(sort=True)
+    'delimiter[;]/num_repeat[1]/string[Bar]'
 
 Last but not least, we can read/write the parameters from/to a file.
 
->>> file = "params.yaml"
->>> params.to_yaml(file)
->>> params2 = audobject.from_yaml(file)
->>> print(params2)
-Name        Value  Default  Choices                Description                            Version
-----        -----  -------  -------                -----------                            -------
-string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
-num_repeat  1      1        None                   the number of times we want to repeat  None
-delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
+.. code-block:: pycon
+
+    >>> file = "params.yaml"
+    >>> params.to_yaml(file)
+    >>> params2 = audobject.from_yaml(file)
+    >>> print(params2)
+    Name        Value  Default  Choices                Description                            Version
+    ----        -----  -------  -------                -----------                            -------
+    string      Bar    None     ['bar', 'Bar', 'BAR']  the string we want to repeat           None
+    num_repeat  1      1        None                   the number of times we want to repeat  None
+    delimiter   ;      ,        None                   defines the delimiter                  >=2.0.0,<3.0.0
 
 .. _timedelta: https://docs.python.org/3/library/datetime.html#timedelta-objects
 .. _argparse: https://docs.python.org/3/library/argparse.html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -920,7 +920,6 @@ by adjusting
     __version__ = "0.9.0"
 
     o3 = audobject.from_yaml_s(o_yaml)
-    print(o3)
 
 .. Silently apply the old-version state for the rest of the section.
 
@@ -931,6 +930,14 @@ by adjusting
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         o3 = audobject.from_yaml_s(o_yaml)
+
+The object is loaded successfully
+and behaves as before.
+
+.. code-block:: pycon
+
+    >>> print(o3)
+    I am a 1.0.0! I am a 1.0.0!
 
 Now we pretend that we update the package to ``2.0.0``.
 It includes a new version of ``MyObject``,
@@ -1077,7 +1084,6 @@ And load it with ``1.0.0``.
             return " ".join([self.string] * self.num_repeat)
 
     o6 = audobject.from_yaml_s(o5_yaml)
-    print(o6)
 
 .. invisible-code-block: python
 
@@ -1097,6 +1103,11 @@ And load it with ``1.0.0``.
 
 In fact, it works, too.
 However, a warning is given that an argument was ignored.
+
+.. code-block:: pycon
+
+    >>> print(o6)
+    I am a 2.1.1! I am a 2.1.1!
 
 Dictionary
 ----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,7 +169,7 @@ Let's create a class where we don't follow this rule.
         def __str__(self) -> str:
             return " ".join([self.msg] * self.repeat)
 
-At a first glance, everything works as expected.
+At first glance, everything works as expected.
 
 .. code-block:: pycon
 
@@ -957,7 +957,7 @@ with a slightly changed ``__str__`` function.
 Since the signature of the constructor has not changed,
 the object will be created without problems.
 However, when we print the object
-the strings are now separated by comma.
+the strings are now separated by a comma.
 
 .. code-block:: pycon
 
@@ -1102,7 +1102,7 @@ Dictionary
 ----------
 
 :class:`audobject.Dictionary` implements a
-:class:`audobject.Object` that can used like a dictionary.
+:class:`audobject.Object` that can be used like a dictionary.
 
 .. code-block:: pycon
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -683,13 +683,6 @@ can be used.
 It encodes the source code of the function
 and dynamically creates the function during decoding.
 
-.. note::
-    The examples in this section require function source code
-    to be stored in a real ``.py`` file,
-    so they are not executed as doctests here.
-
-.. skip: start
-
 The following class takes as arguments a function with two parameters.
 
 .. code-block:: python
@@ -715,44 +708,50 @@ The following class takes as arguments a function with two parameters.
 
 Here, we initialize an object with a function that sums up the two parameters.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    def add(a, b):
-        return a + b
-
-
-    o = MyObjectWithFunction(add)
-    o(1, 2)
+    >>> def add(a, b):
+    ...     return a + b
+    >>> o = MyObjectWithFunction(add)
+    >>> o(1, 2)
+    3
 
 When we serialize the object,
 the definition of our function is stored in plain text.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    o_yaml = o.to_yaml_s()
-    print(o_yaml)
+    >>> o_yaml = o.to_yaml_s()
+    >>> print(o_yaml)
+    $mypkg.MyObjectWithFunction==1.0.0:
+      func: "def add(a, b):\n    return a + b\n"
+    <BLANKLINE>
 
 From which the function can be dynamically initialized
 when the object is recreated.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    o2 = audobject.from_yaml_s(o_yaml)
-    o2(2, 3)
+    >>> o2 = audobject.from_yaml_s(o_yaml)
+    >>> o2(2, 3)
+    5
 
 It also works for lambda expressions.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    o3 = MyObjectWithFunction(lambda a, b: a * b)
+    >>> o3 = MyObjectWithFunction(lambda a, b: a * b)
+    >>> o3_yaml = o3.to_yaml_s()
+    >>> print(o3_yaml)
+    $mypkg.MyObjectWithFunction==1.0.0:
+      func: 'lambda a, b: a * b'
+    <BLANKLINE>
 
-    o3_yaml = o3.to_yaml_s()
-    print(o3_yaml)
+.. code-block:: pycon
 
-.. code-block:: python
-
-    o4 = audobject.from_yaml_s(o3_yaml)
-    o4(2, 3)
+    >>> o4 = audobject.from_yaml_s(o3_yaml)
+    >>> o4(2, 3)
+    6
 
 Instead of a function,
 we can also pass a callable object
@@ -772,28 +771,34 @@ that derives from
         def __call__(self, a: int, b: int):
             return (a + b) * self.n
 
+.. code-block:: pycon
 
-    a_callable_object = MyCallableObject(2)
-    o5 = MyObjectWithFunction(a_callable_object)
-    o5(4, 5)
+    >>> a_callable_object = MyCallableObject(2)
+    >>> o5 = MyObjectWithFunction(a_callable_object)
+    >>> o5(4, 5)
+    18
 
 In that case,
 the YAML representation is store
 instead of the function code.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    o5_yaml = o5.to_yaml_s()
-    print(o5_yaml)
+    >>> o5_yaml = o5.to_yaml_s()
+    >>> print(o5_yaml)
+    $mypkg.MyObjectWithFunction==1.0.0:
+      func:
+        $mypkg.MyCallableObject==1.0.0:
+          n: 2
+    <BLANKLINE>
 
 And we can still restore the original object.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    o6 = audobject.from_yaml_s(o5_yaml)
-    o6(4, 5)
-
-.. skip: end
+    >>> o6 = audobject.from_yaml_s(o5_yaml)
+    >>> o6(4, 5)
+    18
 
 .. warning:: Since the described mechanism
     offers a way to execute arbitrary Python code,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,17 +47,15 @@ documentation = 'https://audeering.github.io/audobject/'
 [dependency-groups]
 dev = [
     'audeer >=2.2.2',
-    'ipykernel',
-    'jupyter-sphinx',
     'parse',
-    'pytest',
-    'pytest-doctestplus',
+    'pytest >=7.0.0',
     'pytest-console-scripts',
     'pytest-cov',
     'sphinx ==5.3.0',
     'sphinx-audeering-theme >=1.2.1',
     'sphinx-autodoc-typehints',
     'sphinx-copybutton',
+    'sybil',
     'toml',
 ]
 
@@ -85,7 +83,7 @@ skip = './audobject.egg-info,./build,./docs/api,./docs/_templates'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
+    -p no:doctest
     --cov=audobject
     --cov-fail-under=100
     --cov-report term-missing

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -46,7 +46,7 @@ class MyObject(audobject.Object):
 
 
 with pytest.warns(RuntimeWarning):
-    audobject.Object.from_yaml_s(o_yaml)
+    audobject.from_yaml_s(o_yaml)
 
 
 # an argument is removed
@@ -62,7 +62,7 @@ class MyObject(audobject.Object):
 
 
 with pytest.warns(RuntimeWarning):
-    audobject.Object.from_yaml_s(o_yaml)
+    audobject.from_yaml_s(o_yaml)
 
 
 # a mandatory argument is added


### PR DESCRIPTION
Replace `jupyter-sphinx` with `sybil` to test the usage documentation.