### PR TITLE
CI: update checkout, setup-python, setup-uv, codecov

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
 
     - name: Test building documentation

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
 
     - name: Test building documentation

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
 
     # PyPI package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,17 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
 
     # PyPI package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Sync Python environment
       run: uv sync
@@ -36,8 +36,8 @@ jobs:
       run: uv run pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Sync Python environment
       run: uv sync


### PR DESCRIPTION
## Summary

Two related CI bugs, both caused by stale GitHub Action version pins:

1. **Dead uv caching**: `astral-sh/setup-uv`'s default `cache-dependency-glob`
   keys on `uv.lock` / `requirements*.txt`, neither of which exists in this
   repo (no committed lockfile, by design). Caching has therefore silently
   never worked. Bumped from `v5` to `v9.0.0`: `v6.0.0` added
   `pyproject.toml` to the default glob, which *is* committed and changes
   exactly when a dependency does — so caching now works with no lockfile
   needed.

2. **Node.js 20 deprecation**: `actions/checkout@v4`, `actions/setup-python@v5`,
   and the old `setup-uv` pin all still targeted the deprecated Node 20
   runtime. Bumped `checkout` and `setup-python` to `v7`, and `setup-uv`'s
   `v7.0.0` also carries the Node 20 → Node 24 runtime bump.
   `codecov/codecov-action@v4` bumped to `v7`; its `v5` rewrite dropped the
   singular `file:` input in favor of `files:` (plural) — renamed
   accordingly in `test.yml` so the coverage upload doesn't silently no-op.
   No `actions/cache` usage exists in this repo's workflows.

`prune-cache` left at its new default (off): audobject's runtime dependencies
(`asttokens`, `audeer`, `oyaml`, `packaging`) have no large pre-built binary
wheels like torch, so pruning would save ~0 disk space while costing
avoidable re-downloads.

## Test plan

- [x] All four changed workflow YAML files validated with
      `uv run --isolated --with pyyaml python3 -c "import yaml; yaml.safe_load(open('FILE'))"`
- [ ] CI passes on this PR (checkout/setup-python/setup-uv/codecov-action
      bumps exercised across the full test matrix)

Part of the same CI cleanup as audeering/audeer#206,
audeering/opensmile-python#132, audeering/audb#591,
audeering/audformat#539, audeering/audbackend#307,
audeering/audresample#83, audeering/auglib#60, audeering/audonnx#115,
audeering/audinterface#206, audeering/audiofile#193,
audeering/audmath#76, and audeering/audmetric#94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)